### PR TITLE
Team Scatterv, Gather, and Gatherv (socket and mpi)

### DIFF
--- a/x10.runtime/src-x10/x10/util/RailUtils.x10
+++ b/x10.runtime/src-x10/x10/util/RailUtils.x10
@@ -185,7 +185,7 @@ public class RailUtils {
      * Return the scan of the given operation over elements of the src Rail
      * storing the results in the dst Rail.
      * On return, the Nth element of dst is the result of applying the
-     * the reduction operation to src elements [0..N-1].
+     * the reduction operation to src elements [0..N].
      * 
      * @param src the source rail for the input to the scan operation
      * @param dst the destination rail for the results of the scan operation.
@@ -218,5 +218,45 @@ public class RailUtils {
                                       op:(T,T)=>T, unit:T):Rail[T] {
         val dst = Unsafe.allocRailUninitialized[T](src.size);
         return scan(src, dst, op, unit);
+    }
+    /**
+     * Return the scan of the given operation over elements of the src Rail
+     * storing the results in the dst Rail.
+     * On return, the first element equals the unit value, and 
+     * the Nth element of dst is the result of applying the
+     * the reduction operation to src elements [0..N-1]. 
+     * 
+     * @param src the source rail for the input to the scan operation
+     * @param dst the destination rail for the results of the scan operation.
+     *   The same array may be passed as both src and dst for an in-place scan.
+     * @param op the reduction function to use in the scan
+     * @param unit the given initial value for the reduction, dst(0) = unit
+     * @return dst after updating its contents to contain the result of the scan
+     */    
+    public static @Inline def scanLeft[T](src:Rail[T], dst:Rail[T],
+                                  op:(T,T)=>T, unit:T):Rail[T]{self==dst} {
+        assert src.size <= dst.size;
+        var accum:T = unit;
+        dst(0) = accum;
+        for (i in 1..(src.size-1)) {
+            accum = op(accum, src(i-1));
+            dst(i) = accum;
+        }
+        return dst;
+    }
+
+    /**
+     * Return a new Rail containing the scan of the given operation over
+     * elements of the src Rail.
+     *
+     * @param src the source rail for the input to the scan operation
+     * @param op the reduction function to use in the scan
+     * @param unit the given initial value for the reduction, dst(0) = unit
+     * @return a new Rail containing the result of the scan
+     */
+    public static @Inline def scanLeft[T](src:Rail[T],
+                                  op:(T,T)=>T, unit:T):Rail[T] {
+        val dst = Unsafe.allocRailUninitialized[T](src.size);
+        return scanLeft(src, dst, op, unit);
     }
 }

--- a/x10.runtime/src-x10/x10/util/Team.x10
+++ b/x10.runtime/src-x10/x10/util/Team.x10
@@ -256,14 +256,14 @@ public struct Team {
      * 
      * @param scounts The number of elements being transferred to each member
      */
-    public def scatterv[T] (root:Place, src:Rail[T], src_off:Long, dst:Rail[T], dst_off:Long, scounts:Rail[Int]) : void {                      
+    public def scatterv[T] (root:Place, src:Rail[T], src_off:Long, dst:Rail[T], dst_off:Long, scounts:Rail[Int]) : void {
         if (CompilerFlags.checkBounds() && here == root) {
             var scounts_sum:Long = 0;
             for (i in 0..(scounts.size-1))
                 scounts_sum += scounts(i);
             checkBounds(src_off + scounts_sum -1, src.size);
         }
-        val my_role = id==0n?here.id() as Int:Team.roles(id);
+        val my_role = (collectiveSupportLevel > X10RT_COLL_NOCOLLECTIVES)? (id==0n?here.id() as Int:Team.roles(id)) : state(id).myIndex;
         val dst_count = scounts(my_role);
         checkBounds(dst_off+dst_count-1, dst.size);
     	if (collectiveSupportLevel == X10RT_COLL_ALLNONBLOCKINGCOLLECTIVES)
@@ -333,7 +333,7 @@ public struct Team {
                 dcounts_sum += dcounts(i);
             checkBounds(dst_off + dcounts_sum -1, dst.size);
         }
-        val my_role = id==0n?here.id() as Int:Team.roles(id);
+        val my_role = (collectiveSupportLevel > X10RT_COLL_NOCOLLECTIVES)? (id==0n?here.id() as Int:Team.roles(id)) : state(id).myIndex;
         val src_count = dcounts(my_role);
         checkBounds(src_off+src_count-1, src.size);
         if (collectiveSupportLevel == X10RT_COLL_ALLNONBLOCKINGCOLLECTIVES)

--- a/x10.runtime/src-x10/x10/util/Team.x10
+++ b/x10.runtime/src-x10/x10/util/Team.x10
@@ -284,10 +284,10 @@ public struct Team {
     //TODO: implement the native calls for scatterv in Java and PAMI
     private static def nativeScatterV[T] (id:Int, role:Int, root:Int, src:Rail[T], src_off:Long, scounts:Rail[Int], dst:Rail[T]) : void {
         val soffsets = new Rail[Int](scounts.size);
-        soffsets(0) = 0n;
+        soffsets(0) = src_off as Int;
         for (y in 1..(scounts.size-1)){
-        	soffsets(y) = soffsets(y-1) + scounts(y-1) + src_off as Int; // include the src_off in the soffsets array for MPI/PAMI  
-        }    
+        	soffsets(y) = soffsets(y-1) + scounts(y-1); // include the src_off in the soffsets array for MPI/PAMI  
+        }
     	//@Native("java", "x10.x10rt.TeamSupport.nativeScatterv(id, role, root, src, soffsets, scounts, dst, scounts[role]);")
     	@Native("c++", "x10rt_scatterv(id, role, root, src->raw, soffsets->raw, scounts->raw, dst->raw, scounts->raw[role], sizeof(TPMGL(T)), ::x10aux::coll_handler, ::x10aux::coll_enter());") {}
     }

--- a/x10.runtime/x10rt/common/x10rt_emu_coll.cc
+++ b/x10.runtime/x10rt/common/x10rt_emu_coll.cc
@@ -831,6 +831,31 @@ void x10rt_emu_scatter (x10rt_team team, x10rt_place role,
     // 'run into' the current barrier causing race conditions
 }
 
+void  x10rt_emu_scatterv (x10rt_team team, x10rt_place role,
+      	                  x10rt_place root, const void *sbuf,
+      	                  const void *soffsets, const void *scounts,
+      	                  void *dbuf, size_t dcount, size_t el,
+      	                  x10rt_completion_handler *ch, void *arg)
+{
+	abort(); //not used by Team.x10
+}
+
+void x10rt_emu_gather (x10rt_team team, x10rt_place role,
+					   x10rt_place root, const void *sbuf,
+					   void *dbuf, size_t el, size_t count,
+					   x10rt_completion_handler *ch, void *arg)
+{
+	abort(); //not used by Team.x10
+}
+
+void x10rt_emu_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
+		                const void *sbuf, size_t scount, void *dbuf,
+		                const void *doffsets, const void *dcounts, size_t el,
+		                x10rt_completion_handler *ch, void *arg)
+{
+	abort(); //not used by Team.x10
+}
+
 void x10rt_emu_bcast (x10rt_team team, x10rt_place role,
                       x10rt_place root, const void *sbuf, void *dbuf,
                       size_t el, size_t count, x10rt_completion_handler *ch, void *arg)

--- a/x10.runtime/x10rt/common/x10rt_front.cc
+++ b/x10.runtime/x10rt/common/x10rt_front.cc
@@ -220,6 +220,31 @@ void x10rt_scatter (x10rt_team team, x10rt_place role,
     x10rt_lgl_scatter(team, role, root, sbuf, dbuf, el, count, ch, arg);
 }
 
+void x10rt_scatterv (x10rt_team team, x10rt_place role,
+                     x10rt_place root, const void *sbuf,
+                     const void *soffsets, const void *scounts,
+                     void *dbuf, size_t dcount, size_t el,
+                     x10rt_completion_handler *ch, void *arg)
+{
+    x10rt_lgl_scatterv(team, role, root, sbuf, soffsets, scounts, dbuf, dcount, el, ch, arg);
+}
+
+
+void x10rt_gather (x10rt_team team, x10rt_place role,
+			       x10rt_place root, const void *sbuf,
+				   void *dbuf, size_t el, size_t count,
+				   x10rt_completion_handler *ch, void *arg)
+{
+	x10rt_lgl_gather (team, role, root, sbuf, dbuf, el, count, ch, arg);
+}
+
+void x10rt_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
+		            const void *sbuf, size_t scount, void *dbuf, const void *doffsets, const void *dcounts,
+		            size_t el, x10rt_completion_handler *ch, void *arg)
+{
+	x10rt_lgl_gatherv (team, role, root, sbuf, scount, dbuf, doffsets, dcounts, el, ch, arg);
+}
+
 void x10rt_alltoall (x10rt_team team, x10rt_place role,
                      const void *sbuf, void *dbuf,
                      size_t el, size_t count,

--- a/x10.runtime/x10rt/common/x10rt_internal.h
+++ b/x10.runtime/x10rt/common/x10rt_internal.h
@@ -157,6 +157,23 @@ X10RT_C void x10rt_emu_scatter (x10rt_team team, x10rt_place role,
                                 x10rt_place root, const void *sbuf, void *dbuf,
                                 size_t el, size_t count,
                                 x10rt_completion_handler *ch, void *arg);
+
+X10RT_C void x10rt_emu_scatterv (x10rt_team team, x10rt_place role,
+        						 x10rt_place root, const void *sbuf, const void *soffsets, const void *scounts,
+        						 void *dbuf, size_t dcount,
+        						 size_t el,
+        						 x10rt_completion_handler *ch, void *arg);
+
+X10RT_C void x10rt_emu_gather (x10rt_team team, x10rt_place role,
+							   x10rt_place root, const void *sbuf,
+							   void *dbuf, size_t el, size_t count,
+							   x10rt_completion_handler *ch, void *arg);
+
+X10RT_C void x10rt_emu_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
+		                        const void *sbuf, size_t scount, void *dbuf,
+		                        const void *doffsets, const void *dcounts,
+		                        size_t el,
+		                        x10rt_completion_handler *ch, void *arg);
     
 X10RT_C void x10rt_emu_alltoall (x10rt_team team, x10rt_place role,
                                  const void *sbuf, void *dbuf,

--- a/x10.runtime/x10rt/common/x10rt_logical.cc
+++ b/x10.runtime/x10rt/common/x10rt_logical.cc
@@ -1086,6 +1086,50 @@ void x10rt_lgl_scatter (x10rt_team team, x10rt_place role,
     }
 }
 
+void x10rt_lgl_scatterv (x10rt_team team, x10rt_place role,
+                        x10rt_place root, const void *sbuf, const void *soffsets, const void *scounts,
+                        void *dbuf, size_t dcount,
+                        size_t el,
+                        x10rt_completion_handler *ch, void *arg)
+{
+    ESCAPE_IF_ERR;
+    if (has_collectives >= X10RT_COLL_ALLBLOCKINGCOLLECTIVES) {
+        x10rt_net_scatterv(team, role, root, sbuf, soffsets, scounts, dbuf, dcount, el, ch, arg);
+    } else {
+        x10rt_emu_scatterv(team, role, root, sbuf, soffsets, scounts, dbuf, dcount, el, ch, arg);
+        while (x10rt_emu_coll_probe());
+    }
+}
+
+void x10rt_lgl_gather (x10rt_team team, x10rt_place role,
+					  x10rt_place root, const void *sbuf,
+					  void *dbuf, size_t el, size_t count,
+					  x10rt_completion_handler *ch, void *arg)
+{
+	ESCAPE_IF_ERR;
+	if (has_collectives >= X10RT_COLL_ALLBLOCKINGCOLLECTIVES) {
+	    x10rt_net_gather(team, role, root, sbuf, dbuf, el, count, ch, arg);
+	} else {
+	    x10rt_emu_gather(team, role, root, sbuf, dbuf, el, count, ch, arg);
+	    while (x10rt_emu_coll_probe());
+	}
+}
+
+void x10rt_lgl_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
+		               const void *sbuf, size_t scount, void *dbuf,
+		               const void *doffsets, const void *dcounts,
+		               size_t el,
+		               x10rt_completion_handler *ch, void *arg)
+{
+	ESCAPE_IF_ERR;
+	if (has_collectives >= X10RT_COLL_ALLBLOCKINGCOLLECTIVES) {
+	    x10rt_net_gatherv(team, role, root, sbuf, scount, dbuf, doffsets, dcounts, el, ch, arg);
+	} else {
+	    x10rt_emu_gatherv(team, role, root, sbuf, scount, dbuf, doffsets, dcounts, el, ch, arg);
+	    while (x10rt_emu_coll_probe());
+	}
+}
+
 void x10rt_lgl_alltoall (x10rt_team team, x10rt_place role,
                          const void *sbuf, void *dbuf,
                          size_t el, size_t count,

--- a/x10.runtime/x10rt/include/x10rt_front.h
+++ b/x10.runtime/x10rt/include/x10rt_front.h
@@ -815,7 +815,7 @@ X10RT_C void x10rt_scatterv (x10rt_team team, x10rt_place role,
  *
  * \param arg User pointer that is passed to the completion handler
  */
-X10RT_C void x10rt_net_gather (x10rt_team team, x10rt_place role,
+X10RT_C void x10rt_gather (x10rt_team team, x10rt_place role,
 							   x10rt_place root, const void *sbuf,
 							   void *dbuf, size_t el, size_t count,
 							   x10rt_completion_handler *ch, void *arg);
@@ -846,7 +846,7 @@ X10RT_C void x10rt_net_gather (x10rt_team team, x10rt_place role,
  *
  * \param arg User pointer that is passed to the completion handler
  */
-X10RT_C void x10rt_net_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
+X10RT_C void x10rt_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
 		                        const void *sbuf, size_t scount, void *dbuf,
 		                        const void *doffsets, const void *dcounts,
 		                        size_t el, x10rt_completion_handler *ch, void *arg);

--- a/x10.runtime/x10rt/include/x10rt_front.h
+++ b/x10.runtime/x10rt/include/x10rt_front.h
@@ -757,6 +757,100 @@ X10RT_C void x10rt_scatter (x10rt_team team, x10rt_place role,
                             size_t el, size_t count,
                             x10rt_completion_handler *ch, void *arg);
 
+/** Asynchronously blocks until all members have received their part of root's array. The number
+ * of elements received by each member can be different. 
+ * Each member receives a contiguous and distinct portion of the sbuf array.  sbuf should be structured so that
+ * the portions are sorted in ascending order, e.g., the first member gets the portion at offset 0
+ * of sbuf, and the last member gets the portion at the end of sbuf.
+ *
+ * \param team Team that identifies the members who are participating in this operation
+ *
+ * \param role Our role in the team
+ *
+ * \param root The member who is supplying the data
+ *
+ * \param sbuf The data that will be sent (will only be used when root == role)
+ * 
+ * \param soffsets the offsets of the members data from the sbuf array
+ * 
+ * \param scounts The number of elements being transferred to each member
+ *
+ * \param dbuf The array into which the data will be received for this member
+ * 
+ * \param dcount The number of elements to be received for this member, should equal scounts[role]
+ *
+ * \param el The size of each element, in bytes
+ *
+ * \param ch Will be called when the operation is complete
+ *
+ * \param arg User pointer that is passed to the completion handler
+ */
+X10RT_C void x10rt_scatterv (x10rt_team team, x10rt_place role,
+                             x10rt_place root, const void *sbuf,
+                             const void *soffsets, const void *scounts,
+                             void *dbuf, size_t dcount, size_t el,
+                             x10rt_completion_handler *ch, void *arg);
+
+
+/** Asynchronously blocks until the root collects all members parts of the root's array. Note that
+ * dbuf is n times the size of sbuf, where n is the number of members in the team.
+ * The root receives the members data and stores them contiguously in the dbuf with the same order 
+ * of the team members.
+ *
+ * \param team Team that identifies the members who are participating in this operation
+ *
+ * \param role Our role in the team
+ *
+ * \param root The member who is supplying the data
+ *
+ * \param sbuf The data that will be sent from each member
+ * 
+ * \param dbuf The array into which the data will be received in the root
+ *
+ * \param el The size of each element, in bytes
+ * 
+ * \param count The number of elements to be sent to the root by each member
+ *
+ * \param ch Will be called when the operation is complete
+ *
+ * \param arg User pointer that is passed to the completion handler
+ */
+X10RT_C void x10rt_net_gather (x10rt_team team, x10rt_place role,
+							   x10rt_place root, const void *sbuf,
+							   void *dbuf, size_t el, size_t count,
+							   x10rt_completion_handler *ch, void *arg);
+
+/** Asynchronously blocks until the root collects all members parts of the root's array. The number of
+ * Elements sent by each member can be different. The root receives the members data and stores them contiguously in the dbuf with the same order 
+ * of the team members.
+ *
+ * \param team Team that identifies the members who are participating in this operation
+ *
+ * \param role Our role in the team
+ *
+ * \param root The member who is supplying the data
+ *
+ * \param sbuf The data that will be sent from each member
+ * 
+ * \param scount The number of elements to be sent by this member, should equal dcounts[role]
+ * 
+ * \param dbuf The array into which the data will be received in the root
+ * 
+ * \param doffsets the offsets of the members data parts in the root's dbuf
+ * 
+ * \param dcounts the number of elements to be received by each member
+ *
+ * \param el The size of each element, in bytes
+ *
+ * \param ch Will be called when the operation is complete
+ *
+ * \param arg User pointer that is passed to the completion handler
+ */
+X10RT_C void x10rt_net_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
+		                        const void *sbuf, size_t scount, void *dbuf,
+		                        const void *doffsets, const void *dcounts,
+		                        size_t el, x10rt_completion_handler *ch, void *arg);
+
 /** Asynchronously blocks until all members have received their portion of data from each 
  * member.  Note that sbuf and dbuf are the same size, which is n*el*count where n is the
  * number of members in the team.  The sbuf is supplied by each member, and is divided up and sent

--- a/x10.runtime/x10rt/include/x10rt_logical.h
+++ b/x10.runtime/x10rt/include/x10rt_logical.h
@@ -411,6 +411,61 @@ X10RT_C void x10rt_lgl_scatter (x10rt_team team, x10rt_place role,
                                 size_t el, size_t count,
                                 x10rt_completion_handler *ch, void *arg);
 
+/** \see #x10rt_scatterv
+ * \param team As in #x10rt_scatterv
+ * \param role As in #x10rt_scatterv
+ * \param root As in #x10rt_scatterv
+ * \param sbuf As in #x10rt_scatterv
+ * \param soffsets As in #x10rt_scatterv
+ * \param scounts As in #x10rt_scatterv
+ * \param dbuf As in #x10rt_scatterv
+ * \param dcount As in #x10rt_scatterv
+ * \param el As in #x10rt_scatterv
+ * \param ch As in #x10rt_scatterv
+ * \param arg As in #x10rt_scatterv
+ */
+X10RT_C void x10rt_lgl_scatterv (x10rt_team team, x10rt_place role,
+                                 x10rt_place root, const void *sbuf,
+                                 const void *soffsets, const void *scounts,
+                                 void *dbuf, size_t dcount,
+                                 size_t el,
+                                 x10rt_completion_handler *ch, void *arg);
+
+/** \see #x10rt_gather
+ * \param team As in #x10rt_gather
+ * \param role As in #x10rt_gather
+ * \param root As in #x10rt_gather
+ * \param sbuf As in #x10rt_gather
+ * \param dbuf As in #x10rt_gather
+ * \param el As in #x10rt_gather
+ * \param count As in #x10rt_gather
+ * \param ch As in #x10rt_gather
+ * \param arg As in #x10rt_gather
+ */
+X10RT_C void x10rt_lgl_gather (x10rt_team team, x10rt_place role,
+					   x10rt_place root, const void *sbuf,
+					   void *dbuf, size_t el, size_t count,
+					   x10rt_completion_handler *ch, void *arg);
+
+/** \see #x10rt_gatherv
+ * \param team As in #x10rt_gatherv
+ * \param role As in #x10rt_gatherv
+ * \param root As in #x10rt_gatherv
+ * \param sbuf As in #x10rt_gatherv
+ * \param scount As in #x10rt_gatherv
+ * \param dbuf As in #x10rt_gatherv
+ * \param doffsets As in #x10rt_gatherv
+ * \param dcounts As in #x10rt_gatherv
+ * \param el As in #x10rt_gatherv
+ * \param ch As in #x10rt_gatherv
+ * \param arg As in #x10rt_gatherv
+ */
+X10RT_C void x10rt_lgl_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
+		                const void *sbuf, size_t scount, void *dbuf,
+		                const void *doffsets, const void *dcounts,
+		                size_t el,
+		                x10rt_completion_handler *ch, void *arg);
+
 /** \see #x10rt_alltoall
  * \param team As in #x10rt_alltoall
  * \param role As in #x10rt_alltoall

--- a/x10.runtime/x10rt/include/x10rt_net.h
+++ b/x10.runtime/x10rt/include/x10rt_net.h
@@ -257,6 +257,59 @@ X10RT_C void x10rt_net_scatter (x10rt_team team, x10rt_place role,
                                 size_t el, size_t count,
                                 x10rt_completion_handler *ch, void *arg);
 
+/** \see #x10rt_lgl_scatterv
+ * \param team As in #x10rt_lgl_scatterv
+ * \param role As in #x10rt_lgl_scatterv
+ * \param root As in #x10rt_lgl_scatterv
+ * \param sbuf As in #x10rt_lgl_scatterv
+ * \param soffsets As in #x10rt_lgl_scatterv
+ * \param scounts As in #x10rt_lgl_scatterv
+ * \param dbuf As in #x10rt_lgl_scatterv
+ * \param dcount As in #x10rt_lgl_scatterv
+ * \param el As in #x10rt_lgl_scatterv
+ * \param ch As in #x10rt_lgl_scatterv
+ * \param arg As in #x10rt_lgl_scatterv
+ */
+X10RT_C void x10rt_net_scatterv (x10rt_team team, x10rt_place role,
+                                 x10rt_place root, const void *sbuf, const void *soffsets, const void *scounts,
+                                 void *dbuf, size_t dcount,
+                                 size_t el,
+                                 x10rt_completion_handler *ch, void *arg);
+/** \see #x10rt_lgl_gather
+ * \param team As in #x10rt_lgl_gather
+ * \param role As in #x10rt_lgl_gather
+ * \param root As in #x10rt_lgl_gather
+ * \param sbuf As in #x10rt_lgl_gather
+ * \param dbuf As in #x10rt_lgl_gather
+ * \param el As in #x10rt_lgl_gather
+ * \param count As in #x10rt_lgl_gather
+ * \param ch As in #x10rt_lgl_gather
+ * \param arg As in #x10rt_lgl_gather
+ */
+X10RT_C void x10rt_net_gather (x10rt_team team, x10rt_place role,
+							   x10rt_place root, const void *sbuf,
+							   void *dbuf, size_t el, size_t count,
+							   x10rt_completion_handler *ch, void *arg);
+
+
+/** \see #x10rt_lgl_gatherv
+ * \param team As in #x10rt_lgl_gatherv
+ * \param role As in #x10rt_lgl_gatherv
+ * \param root As in #x10rt_lgl_gatherv
+ * \param sbuf As in #x10rt_lgl_gatherv
+ * \param scount As in #x10rt_lgl_gatherv
+ * \param dbuf As in #x10rt_lgl_gatherv
+ * \param doffsets As in #x10rt_lgl_gatherv
+ * \param dcounts As in #x10rt_lgl_gatherv
+ * \param el As in #x10rt_lgl_gatherv
+ * \param ch As in #x10rt_lgl_gatherv
+ * \param arg As in #x10rt_lgl_gatherv
+ */
+X10RT_C void x10rt_net_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
+		                        const void *sbuf, size_t scount, void *dbuf, const void *doffsets, const void *dcounts,
+		                        size_t el,
+		                        x10rt_completion_handler *ch, void *arg);
+
 /** \see #x10rt_lgl_alltoall
  * \param team As in #x10rt_lgl_alltoall
  * \param role As in #x10rt_lgl_alltoall

--- a/x10.runtime/x10rt/pami/x10rt_pami.cc
+++ b/x10.runtime/x10rt/pami/x10rt_pami.cc
@@ -1901,6 +1901,28 @@ void x10rt_net_scatter (x10rt_team team, x10rt_place role, x10rt_place root, con
     // The local copy is not needed.  PAMI handles this for us.
 }
 
+void x10rt_net_scatterv (x10rt_team team, x10rt_place role, x10rt_place root,
+		const void *sbuf, const void *soffsets, const void *scounts,
+		void *dbuf, size_t dcount, size_t el, x10rt_completion_handler *ch, void *arg)
+{
+	//TODO: implement PAMI scatterv
+	fatal_error("x10rt_net_scatterv not implemented");
+}
+
+void x10rt_net_gather (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf,
+		void *dbuf, size_t el, size_t count, x10rt_completion_handler *ch, void *arg)
+{
+	//TODO: implement PAMI gather
+	fatal_error("x10rt_net_gather not implemented");
+}
+
+void x10rt_net_gatherv (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf, size_t scount,
+		void *dbuf, const void *doffsets, const void *dcounts, size_t el, x10rt_completion_handler *ch, void *arg)
+{
+	//TODO: implement PAMI gatherv
+	fatal_error("x10rt_net_gatherv not implemented");
+}
+
 void x10rt_net_alltoall (x10rt_team team, x10rt_place role, const void *sbuf, void *dbuf,
 		size_t el, size_t count, x10rt_completion_handler *ch, void *arg)
 {

--- a/x10.runtime/x10rt/sockets/x10rt_sockets.cc
+++ b/x10.runtime/x10rt/sockets/x10rt_sockets.cc
@@ -1497,6 +1497,24 @@ void x10rt_net_scatter (x10rt_team team, x10rt_place role, x10rt_place root, con
 	fatal_error("x10rt_net_scatter not implemented");
 }
 
+void x10rt_net_scatterv (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf, const void *soffsets, const void *scounts,
+		void *dbuf, size_t dcount, size_t el, x10rt_completion_handler *ch, void *arg)
+{
+	fatal_error("x10rt_net_scatterv not implemented");
+}
+
+void x10rt_net_gather (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf,
+		void *dbuf, size_t el, size_t count, x10rt_completion_handler *ch, void *arg)
+{
+	fatal_error("x10rt_net_gather not implemented");
+}
+
+void x10rt_net_gatherv (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf, size_t scount,
+		void *dbuf, const void *doffsets, const void *dcounts, size_t el, x10rt_completion_handler *ch, void *arg)
+{
+	fatal_error("x10rt_net_gatherv not implemented");
+}
+
 void x10rt_net_alltoall (x10rt_team team, x10rt_place role, const void *sbuf, void *dbuf,
 		size_t el, size_t count, x10rt_completion_handler *ch, void *arg)
 {

--- a/x10.runtime/x10rt/standalone/x10rt_standalone.cc
+++ b/x10.runtime/x10rt/standalone/x10rt_standalone.cc
@@ -987,6 +987,31 @@ void x10rt_net_scatter (x10rt_team team, x10rt_place role,
     abort();
 }
 
+void x10rt_net_scatterv (x10rt_team team, x10rt_place role,
+                         x10rt_place root, const void *sbuf,
+                         const void *soffsets, const void *scounts,
+                         void *dbuf, size_t dcount, size_t el,
+                         x10rt_completion_handler *ch, void *arg)
+{
+    abort();
+}
+
+void x10rt_net_gather (x10rt_team team, x10rt_place role,
+		               x10rt_place root, const void *sbuf,
+		               void *dbuf, size_t el, size_t count,
+		               x10rt_completion_handler *ch, void *arg)
+{
+	abort();
+}
+
+void x10rt_net_gatherv (x10rt_team team, x10rt_place role,
+		                x10rt_place root, const void *sbuf, size_t scount,
+		                void *dbuf, const void *doffsets, const void *dcounts,
+		                size_t el, x10rt_completion_handler *ch, void *arg)
+{
+	abort();
+}
+
 void x10rt_net_alltoall (x10rt_team team, x10rt_place role,
                          const void *sbuf, void *dbuf,
                          size_t el, size_t count,

--- a/x10.tests/tests/MicroBenchmarks/BenchmarkGather.x10
+++ b/x10.tests/tests/MicroBenchmarks/BenchmarkGather.x10
@@ -1,0 +1,64 @@
+/*
+ *  This file is part of the X10 project (http://x10-lang.org).
+ *
+ *  This file is licensed to You under the Eclipse Public License (EPL);
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      http://www.opensource.org/licenses/eclipse-1.0.php
+ *
+ *  (C) Copyright IBM Corporation 2014-2015.
+ */
+import harness.x10Test;
+
+import x10.util.Team;
+
+/**
+ * Benchmarks performance of Team.gather 
+ */
+public class BenchmarkGather extends x10Test {
+    private static ITERS = 10;
+    private static COUNT_PER_PLACE = 2<<19;
+    private static SRC_OFFSET = 5;
+    private static DST_OFFSET = 3;
+    
+    public def run(): Boolean {
+        // root=nplaces/2  hangs starting from using  5 places
+        val root = Place(Place.numPlaces()-1);
+        
+        finish for (place in Place.places()) at (place) async {
+            val warmupIn = new Rail[Double](1);
+            var warmupOut:Rail[Double] = new Rail[Double](Place.numPlaces());
+            Team.WORLD.gather(root,warmupIn, 0, warmupOut, 0, 1); // warm up comms layer
+            for (var s:Long= 1; s <= COUNT_PER_PLACE; s *= 2) {
+                var dst:Rail[Double] = null;
+                val dstSize = s*Place.numPlaces()+DST_OFFSET;
+                if (here.id == root.id){
+                    dst = new Rail[Double](dstSize);
+                }
+                val srcSize = s + SRC_OFFSET;
+                val src = new Rail[Double](srcSize, (i:Long) => here.id as Double);
+                
+                val start = System.nanoTime();
+                for (iter in 1..ITERS) {
+                    Team.WORLD.gather(root, src, SRC_OFFSET, dst, DST_OFFSET, s);
+                }
+                val stop = System.nanoTime();
+                
+                // check correctness
+                if (here.id == root.id){
+                    for (i in DST_OFFSET..(dstSize-1)) {
+                        val expectedValue = (i-DST_OFFSET)/s;
+                        chk(dst(i) == expectedValue as Double , "elem " + i + " is " + dst(i) + " should be " + expectedValue);
+                    }
+                }
+
+                if (here == Place.FIRST_PLACE) Console.OUT.printf("gather %d: %g ms\n", s, ((stop-start) as Double) / 1e6 / ITERS);
+            }
+        }
+        return true;
+    }
+
+    public static def main(var args: Rail[String]): void {
+        new BenchmarkGather().execute();
+    }
+}

--- a/x10.tests/tests/MicroBenchmarks/BenchmarkGatherV.x10
+++ b/x10.tests/tests/MicroBenchmarks/BenchmarkGatherV.x10
@@ -1,0 +1,76 @@
+/*
+ *  This file is part of the X10 project (http://x10-lang.org).
+ *
+ *  This file is licensed to You under the Eclipse Public License (EPL);
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      http://www.opensource.org/licenses/eclipse-1.0.php
+ *
+ *  (C) Copyright IBM Corporation 2014-2015.
+ */
+import harness.x10Test;
+
+import x10.util.Team;
+
+/**
+ * Benchmarks performance of Team.gatherv
+ */
+public class BenchmarkGatherV extends x10Test {
+    private static ITERS = 10;
+    private static MAX_S = 17;
+    private static SRC_OFFSET = 5;
+    private static DST_OFFSET = 3;
+
+    public def run(): Boolean {
+        // root=nplaces/2  hangs starting from using  5 places
+        val NPLACES = Place.numPlaces();
+        val root = Place(NPLACES-1);
+
+        finish for (place in Place.places()) at (place) async {
+            val warmupIn = new Rail[Double](1);
+            var warmupOut:Rail[Double] = new Rail[Double](NPLACES);
+            val warmupCounts = new Rail[Int](NPLACES, 1n);
+            Team.WORLD.gatherv(root,warmupIn, 0, warmupOut, 0, warmupCounts); // warm up comms layer
+            
+            for (var s:Long= 1; s <= MAX_S; s++) {
+                var dst:Rail[Double] = null;
+                val svalue = s;
+                val dcounts = new Rail[Int](NPLACES, (i:Long) => (Math.pow(2,svalue) * (i + 1)) as Int);
+                //the segment size at place i is 2^S*(i+1)
+                //the summation of the series SEGMA(j=1..N){j} = (N * N+1 / 2))
+                val dstSize = (Math.pow(2,s) * (NPLACES * (NPLACES+1)/2) + DST_OFFSET) as Long;
+
+                if (here.id == root.id){
+                    dst = new Rail[Double](dstSize);
+                }
+
+                val srcSize = (Math.pow(2,s) * (here.id + 1)) as Long + SRC_OFFSET;
+                val src = new Rail[Double](srcSize, (i:Long) => here.id as Double);
+
+                val start = System.nanoTime();
+                for (iter in 1..ITERS) {
+                    Team.WORLD.gatherv(root,src, SRC_OFFSET, dst, DST_OFFSET, dcounts);
+                }
+                val stop = System.nanoTime();
+
+                // check correctness
+                if (here.id == root.id){
+                    var indx:Long = DST_OFFSET;
+                    for (i in 0..(dcounts.size-1)){
+                        val expectedValue = i;
+                        for (k in 1..dcounts(i)){
+                            chk(dst(indx) == expectedValue as Double , "elem " + indx + " is " + dst(indx) + " should be " + expectedValue);
+                            indx++;
+                        }
+                    }
+                }
+
+                if (here == Place.FIRST_PLACE) Console.OUT.printf("gatherV %d: %g ms\n", dstSize, ((stop-start) as Double) / 1e6 / ITERS);
+            }
+        }
+        return true;
+    }
+    public static def main(var args: Rail[String]): void {
+        new BenchmarkGatherV().execute();
+    }
+}

--- a/x10.tests/tests/MicroBenchmarks/BenchmarkScatterV.x10
+++ b/x10.tests/tests/MicroBenchmarks/BenchmarkScatterV.x10
@@ -1,0 +1,80 @@
+/*
+ *  This file is part of the X10 project (http://x10-lang.org).
+ *
+ *  This file is licensed to You under the Eclipse Public License (EPL);
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      http://www.opensource.org/licenses/eclipse-1.0.php
+ *
+ *  (C) Copyright IBM Corporation 2014-2015.
+ */
+import harness.x10Test;
+
+import x10.util.Team;
+
+/**
+ * Benchmarks performance of Team.scatterV 
+ */
+public class BenchmarkScatterV extends x10Test {
+    private static ITERS = 10;
+    private static MAX_S = 17;
+    private static SRC_OFFSET = 5;
+    
+	public def run(): Boolean {
+        // root=nplaces/2  hangs starting from using  5 places
+        val NPLACES = Place.numPlaces();
+        val root = Place(NPLACES-1);
+        
+        finish for (place in Place.places()) at (place) async {
+        	val warmupIn = new Rail[Double](NPLACES);
+            var warmupOut:Rail[Double] = new Rail[Double](1);
+            val warmupCounts = new Rail[Long](NPLACES, 1);
+            Team.WORLD.scatterv(root,warmupIn, 0, warmupOut, 0, warmupCounts); // warm up comms layer
+            
+            for (var s:Long= 1; s <= MAX_S; s++) {
+                var src:Rail[Double] = null;                
+                val svalue = s;
+                val scounts = new Rail[Long](NPLACES, (i:Long) => (Math.pow(2,svalue) * (i + 1)) as Long);                
+                //the segment size at place i is 2^S*(i+1) --> i=0..NPLACES-1
+                //the summation of the series SEGMA(j=1..N){j} = (N * N+1 / 2))
+                val srcSize = (Math.pow(2,s) * (NPLACES * (NPLACES+1)/2) + SRC_OFFSET) as Long; 
+                
+                if (here.id == root.id){
+                	src = new Rail[Double](srcSize);
+                    var lastPlaceId:Long = 0;
+                    var it:Long = SRC_OFFSET;
+                    //initialize the src rail so that each place segment contains its the place id as a value
+                    while(it<srcSize){
+                        for (var j:Long = 0; j < (Math.pow(2,s)*(lastPlaceId+1)) as Long; j++){
+                        	src(it++) = lastPlaceId;
+                        }
+                        lastPlaceId++;
+                    }
+                }
+                
+                val dstSize = (Math.pow(2,s) * (here.id + 1)) as Long;
+                val dst = new Rail[Double](dstSize);
+                
+                val start = System.nanoTime();
+                for (iter in 1..ITERS) {
+                    Team.WORLD.scatterv(root,src, SRC_OFFSET, dst, 0, scounts);
+                }
+                val stop = System.nanoTime();
+                
+                // check correctness
+                for (i in 0..(dstSize-1)) {
+                    val expectedValue = here.id;
+                    chk(dst(i) == expectedValue as Double , "elem " + i + " is " + dst(i) + " should be " + expectedValue);
+                }
+
+                if (here == Place.FIRST_PLACE) Console.OUT.printf("scatterV %d: %g ms\n", srcSize, ((stop-start) as Double) / 1e6 / ITERS);                
+            }
+        }
+
+        return true;
+	}
+
+	public static def main(var args: Rail[String]): void {
+		new BenchmarkScatterV().execute();
+	}
+}

--- a/x10.tests/tests/MicroBenchmarks/BenchmarkScatterV.x10
+++ b/x10.tests/tests/MicroBenchmarks/BenchmarkScatterV.x10
@@ -13,68 +13,68 @@ import harness.x10Test;
 import x10.util.Team;
 
 /**
- * Benchmarks performance of Team.scatterV 
+ * Benchmarks performance of Team.scatterV
  */
 public class BenchmarkScatterV extends x10Test {
     private static ITERS = 10;
     private static MAX_S = 17;
     private static SRC_OFFSET = 5;
-    
-	public def run(): Boolean {
+    private static DST_OFFSET = 3;
+
+    public def run(): Boolean {
         // root=nplaces/2  hangs starting from using  5 places
         val NPLACES = Place.numPlaces();
         val root = Place(NPLACES-1);
-        
+
         finish for (place in Place.places()) at (place) async {
-        	val warmupIn = new Rail[Double](NPLACES);
+            val warmupIn = new Rail[Double](NPLACES);
             var warmupOut:Rail[Double] = new Rail[Double](1);
             val warmupCounts = new Rail[Int](NPLACES, 1n);
             Team.WORLD.scatterv(root,warmupIn, 0, warmupOut, 0, warmupCounts); // warm up comms layer
-            
+
             for (var s:Long= 1; s <= MAX_S; s++) {
-                var src:Rail[Double] = null;                
+                var src:Rail[Double] = null;
                 val svalue = s;
-                val scounts = new Rail[Int](NPLACES, (i:Long) => (Math.pow(2,svalue) * (i + 1)) as Int);                
+                val scounts = new Rail[Int](NPLACES, (i:Long) => (Math.pow(2,svalue) * (i + 1)) as Int);
                 //the segment size at place i is 2^S*(i+1) --> i=0..NPLACES-1
                 //the summation of the series SEGMA(j=1..N){j} = (N * N+1 / 2))
-                val srcSize = (Math.pow(2,s) * (NPLACES * (NPLACES+1)/2) + SRC_OFFSET) as Long; 
-                
+                val srcSize = (Math.pow(2,s) * (NPLACES * (NPLACES+1)/2) + SRC_OFFSET) as Long;
+
                 if (here.id == root.id){
-                	src = new Rail[Double](srcSize);
+                    src = new Rail[Double](srcSize);
                     var lastPlaceId:Long = 0;
                     var it:Long = SRC_OFFSET;
                     //initialize the src rail so that each place segment contains its the place id as a value
                     while(it<srcSize){
                         for (var j:Long = 0; j < (Math.pow(2,s)*(lastPlaceId+1)) as Long; j++){
-                        	src(it++) = lastPlaceId;
+                            src(it++) = lastPlaceId;
                         }
                         lastPlaceId++;
                     }
                 }
-                
-                val dstSize = (Math.pow(2,s) * (here.id + 1)) as Long;
+
+                val dstSize = (Math.pow(2,s) * (here.id + 1)) as Long + DST_OFFSET;
                 val dst = new Rail[Double](dstSize);
-                
+
                 val start = System.nanoTime();
                 for (iter in 1..ITERS) {
-                    Team.WORLD.scatterv(root,src, SRC_OFFSET, dst, 0, scounts);
+                    Team.WORLD.scatterv(root,src, SRC_OFFSET, dst, DST_OFFSET, scounts);
                 }
                 val stop = System.nanoTime();
-                
+
                 // check correctness
-                for (i in 0..(dstSize-1)) {
+                for (i in DST_OFFSET..(dstSize-1)) {
                     val expectedValue = here.id;
                     chk(dst(i) == expectedValue as Double , "elem " + i + " is " + dst(i) + " should be " + expectedValue);
                 }
 
-                if (here == Place.FIRST_PLACE) Console.OUT.printf("scatterV %d: %g ms\n", srcSize, ((stop-start) as Double) / 1e6 / ITERS);                
+                if (here == Place.FIRST_PLACE) Console.OUT.printf("scatterV %d: %g ms\n", srcSize, ((stop-start) as Double) / 1e6 / ITERS);
             }
         }
 
         return true;
-	}
-
-	public static def main(var args: Rail[String]): void {
-		new BenchmarkScatterV().execute();
-	}
+    }
+    public static def main(var args: Rail[String]): void {
+        new BenchmarkScatterV().execute();
+    }
 }

--- a/x10.tests/tests/MicroBenchmarks/BenchmarkScatterV.x10
+++ b/x10.tests/tests/MicroBenchmarks/BenchmarkScatterV.x10
@@ -28,13 +28,13 @@ public class BenchmarkScatterV extends x10Test {
         finish for (place in Place.places()) at (place) async {
         	val warmupIn = new Rail[Double](NPLACES);
             var warmupOut:Rail[Double] = new Rail[Double](1);
-            val warmupCounts = new Rail[Long](NPLACES, 1);
+            val warmupCounts = new Rail[Int](NPLACES, 1n);
             Team.WORLD.scatterv(root,warmupIn, 0, warmupOut, 0, warmupCounts); // warm up comms layer
             
             for (var s:Long= 1; s <= MAX_S; s++) {
                 var src:Rail[Double] = null;                
                 val svalue = s;
-                val scounts = new Rail[Long](NPLACES, (i:Long) => (Math.pow(2,svalue) * (i + 1)) as Long);                
+                val scounts = new Rail[Int](NPLACES, (i:Long) => (Math.pow(2,svalue) * (i + 1)) as Int);                
                 //the segment size at place i is 2^S*(i+1) --> i=0..NPLACES-1
                 //the summation of the series SEGMA(j=1..N){j} = (N * N+1 / 2))
                 val srcSize = (Math.pow(2,s) * (NPLACES * (NPLACES+1)/2) + SRC_OFFSET) as Long; 

--- a/x10.tests/tests/MicroBenchmarks/BenchmarkScatterV.x10
+++ b/x10.tests/tests/MicroBenchmarks/BenchmarkScatterV.x10
@@ -13,7 +13,7 @@ import harness.x10Test;
 import x10.util.Team;
 
 /**
- * Benchmarks performance of Team.scatterV
+ * Benchmarks performance of Team.scatterv
  */
 public class BenchmarkScatterV extends x10Test {
     private static ITERS = 10;


### PR DESCRIPTION
Changes to support the collective operations scatterv, gather and gatherv in Teams. The new methods are currently implemented only for the sockets and MPI runtimes.  Jave and PAMI will be supported later.