### PR TITLE
Resilient Team Issues

### DIFF
--- a/x10.runtime/src-x10/x10/util/Team.x10
+++ b/x10.runtime/src-x10/x10/util/Team.x10
@@ -1089,7 +1089,7 @@ public struct Team {
              * another activity, giving preference to activities running
              * locally on another worker thread.
              */
-            val sleepUntil = (condition:() => Boolean) => @NoInline {
+            val sleepUntil = (condition:() => Boolean):Boolean => @NoInline {
                 if (!condition() && Team.state(teamidcopy).isValid) {
                     Runtime.increaseParallelism();
                     while (!condition() && Team.state(teamidcopy).isValid) {
@@ -1111,15 +1111,17 @@ public struct Team {
                     }
                     Runtime.decreaseParallelism(1n);
                 }
+                return Team.state(teamidcopy).isValid;
             };
 
             // block if some other collective is in progress.
             // note that local indexes are not yet set up, so we won't check for dead places in this call
             sleepUntil(() => this.phase.compareAndSet(PHASE_READY, PHASE_INIT));
             
-            // don't do anything if this team was previously set to invalid
-            if (!Team.state(this.teamid).isValid)
-                throw new DeadPlaceException("Team "+this.teamid+" contains at least one dead member");
+            //// commented to allow the place to notify its children with the invalid team status before leaving the collection
+            //// don't do anything if this team was previously set to invalid
+            //if (!Team.state(this.teamid).isValid)
+            //    throw new DeadPlaceException("Team "+this.teamid+" contains at least one dead member");
             
             // figure out our links in the tree structure
             val myLinks:TreeStructure;
@@ -1214,8 +1216,10 @@ public struct Team {
             
             try { // try/catch for DeadPlaceExceptions associated with the 'at' statements
 	            // wait for phase updates from children
-	            if (DEBUGINTERNALS) Runtime.println(here+":team"+teamidcopy+" waiting for children phase "+Team.state(teamidcopy).phase.get());
-	            sleepUntil(() => this.phase.get() == PHASE_SCATTER);
+	            if (DEBUGINTERNALS) Runtime.println(here+":team"+teamidcopy+" waiting for children phase "+Team.state(teamidcopy).phase.get());            
+	            if (!sleepUntil(() => this.phase.get() == PHASE_SCATTER)){
+	                throw new MultipleExceptions(new DeadPlaceException("Team "+teamidcopy+" contains at least one dead member"));
+	            }
 	            if (DEBUGINTERNALS) Runtime.println(here+":team"+teamidcopy+" released by children phase "+Team.state(teamidcopy).phase.get());
 	
 	            if (collType == COLL_REDUCE || collType == COLL_ALLREDUCE) {
@@ -1244,12 +1248,17 @@ public struct Team {
 	                    local_temp_buff = src;
 	                this.phase.set(PHASE_DONE); // the root node has no parent, and can skip its own state ahead
 	            } else {
-	                val waitForParentToReceive = () => @NoInline {
-	                    if (DEBUGINTERNALS) Runtime.println(here+" waiting for parent phase "+Team.state(teamidcopy).phase.get());
-	                     sleepUntil(() => {val state = Team.state(teamidcopy).phase.get();
+	                val waitForParentToReceive = ():Boolean => @NoInline {
+	                    val isValid = sleepUntil(() => {val state = Team.state(teamidcopy).phase.get();
 	                                       (state >= PHASE_GATHER1 && state < PHASE_SCATTER)
 	                                      });
-	                    if (DEBUGINTERNALS) Runtime.println(here+" parent ready to receive phase "+Team.state(teamidcopy).phase.get());
+	                    if (DEBUGINTERNALS) {
+	                        if (isValid)
+	                            Runtime.println(here+" parent ready to receive phase "+Team.state(teamidcopy).phase.get());
+	                        else
+	                            Runtime.println(here+" parent can not receive, team " + teamidcopy + " is invalid ");
+	                    }
+	                    return isValid;
 	                };
 	
 	                val incrementParentPhase = () => @NoInline {
@@ -1270,10 +1279,11 @@ public struct Team {
 	                        val sourceIndex = myIndex;
 	                        val totalData = count*(myLinks.totalChildren+1);
 	                        at (places(myLinks.parentIndex)) @Uncounted async {
-	                            waitForParentToReceive();
-	if (DEBUGINTERNALS) Runtime.println(here+ " alltoall gathering from offset "+(dst_off+(count*sourceIndex))+" to local_dst_off "+(Team.state(teamidcopy).local_dst_off+(count*sourceIndex))+" size " + totalData);
-	                            // copy my data, plus all the data filled in by my children, to my parent
-	                            Rail.uncountedCopy(gr, dst_off+(count*sourceIndex), Team.state(teamidcopy).local_dst as Rail[T], Team.state(teamidcopy).local_dst_off+(count*sourceIndex), totalData, incrementParentPhase);
+	                            if (waitForParentToReceive()) {
+	                                if (DEBUGINTERNALS) Runtime.println(here+ " alltoall gathering from offset "+(dst_off+(count*sourceIndex))+" to local_dst_off "+(Team.state(teamidcopy).local_dst_off+(count*sourceIndex))+" size " + totalData);
+	                                // copy my data, plus all the data filled in by my children, to my parent
+	                                Rail.uncountedCopy(gr, dst_off+(count*sourceIndex), Team.state(teamidcopy).local_dst as Rail[T], Team.state(teamidcopy).local_dst_off+(count*sourceIndex), totalData, incrementParentPhase);
+	                            }
 	                        }
 	                        gr.forget();
 	                    } else if (collType == COLL_REDUCE || collType == COLL_ALLREDUCE) {
@@ -1282,68 +1292,75 @@ public struct Team {
 	                        // copy reduced data to parent
 	                        val sourceIndex = places.indexOf(here);
 	                        at (places(myLinks.parentIndex)) @Uncounted async {
-	                            waitForParentToReceive();
-	                            var target:Rail[T];
-	                            var off:Long;
-	                            if (sourceIndex == Team.state(teamidcopy).local_child2Index) {
-	                                target = Team.state(teamidcopy).local_temp_buff2 as Rail[T];
-	                                off = 0;
-	                            } else if (Team.state(teamidcopy).local_src == Team.state(teamidcopy).local_dst) {
-	                                target = Team.state(teamidcopy).local_temp_buff as Rail[T];
-	                                off = 0;
-	                            } else {
-	                                // child 1 data written directly to dst
-	                                target = Team.state(teamidcopy).local_dst as Rail[T];
-	                                off = Team.state(teamidcopy).local_dst_off;
+	                            if(waitForParentToReceive()) {
+	                                var target:Rail[T];
+	                                var off:Long;
+	                                if (sourceIndex == Team.state(teamidcopy).local_child2Index) {
+	                                    target = Team.state(teamidcopy).local_temp_buff2 as Rail[T];
+	                                    off = 0;
+	                                } else if (Team.state(teamidcopy).local_src == Team.state(teamidcopy).local_dst) {
+	                                    target = Team.state(teamidcopy).local_temp_buff as Rail[T];
+	                                    off = 0;
+	                                } else {
+	                                    // child 1 data written directly to dst
+	                                    target = Team.state(teamidcopy).local_dst as Rail[T];
+	                                    off = Team.state(teamidcopy).local_dst_off;
+	                                }
+	                                Rail.uncountedCopy(gr, dst_off, target, off, count, incrementParentPhase);
 	                            }
-	                            Rail.uncountedCopy(gr, dst_off, target, off, count, incrementParentPhase);
 	                        }
 	                        gr.forget();
 	                    } else if (collType == COLL_INDEXOFMAX) {
 	                        val childVal:DoubleIdx = dst(0) as DoubleIdx;
 	                        at (places(myLinks.parentIndex)) @Uncounted async {
-	                            waitForParentToReceive();
-	                            sleepUntil(() => Team.state(teamidcopy).dstLock.tryLock());
-	                            val ldi:Rail[DoubleIdx] = (Team.state(teamidcopy).local_dst as Rail[DoubleIdx]);
-	                            if (DEBUGINTERNALS) Runtime.println(here+" IndexOfMax: parent="+ldi(0).value+" child="+childVal.value);
-	                            
-	                            // TODO: If there is  more than one instance of the min/max value, this 
-	                            // implementation will return the index associated with "one of" them, not necessarily
-	                            // the first one.  Do we need to return the "first", as the API says, or is that not really necessary?
-	                            if (childVal.value > ldi(0).value)
-	                                ldi(0) = childVal;
-	                            Team.state(teamidcopy).dstLock.unlock();
-	                            incrementParentPhase();
+	                            if (waitForParentToReceive()) {
+	                                if (sleepUntil(() => Team.state(teamidcopy).dstLock.tryLock())){
+	                                    val ldi:Rail[DoubleIdx] = (Team.state(teamidcopy).local_dst as Rail[DoubleIdx]);
+	                                    if (DEBUGINTERNALS) Runtime.println(here+" IndexOfMax: parent="+ldi(0).value+" child="+childVal.value);
+	            
+	                                    // TODO: If there is  more than one instance of the min/max value, this 
+	                                    // implementation will return the index associated with "one of" them, not necessarily
+	                                    // the first one.  Do we need to return the "first", as the API says, or is that not really necessary?
+	                                    if (childVal.value > ldi(0).value)
+	                                        ldi(0) = childVal;
+	                                    Team.state(teamidcopy).dstLock.unlock();
+	                                    incrementParentPhase();
+	                                }
+	                            }
 	                        }
 	                    } else if (collType == COLL_INDEXOFMIN) {
 	                        val childVal:DoubleIdx = dst(0) as DoubleIdx;
 	                        at (places(myLinks.parentIndex)) @Uncounted async {
-	                            waitForParentToReceive();
-	                            sleepUntil(() => Team.state(teamidcopy).dstLock.tryLock());
-	                            val ldi:Rail[DoubleIdx] = (Team.state(teamidcopy).local_dst as Rail[DoubleIdx]);
-	                            if (childVal.value < ldi(0).value)
-	                                ldi(0) = childVal;
-	                            Team.state(teamidcopy).dstLock.unlock();
-	                            incrementParentPhase();
+	                            if (waitForParentToReceive()) {
+	                                if (sleepUntil(() => Team.state(teamidcopy).dstLock.tryLock())){
+	                                    val ldi:Rail[DoubleIdx] = (Team.state(teamidcopy).local_dst as Rail[DoubleIdx]);
+	                                    if (childVal.value < ldi(0).value)
+	                                        ldi(0) = childVal;
+	                                    Team.state(teamidcopy).dstLock.unlock();
+	                                    incrementParentPhase();
+	                                }
+	                            }
 	                         }
 	                    } else if (collType == COLL_GATHER || collType == COLL_GATHERV) {	                        	                        
 	                        val notNullTmp = local_temp_buff as Rail[T]{self!=null};
 	                        val grTmp = new GlobalRail[T](notNullTmp);
 	                        val childOffset = local_offset;
-	                        val childTotalData = local_counts_sum;	                        
+	                        val childTotalData = local_counts_sum;
 	                        at (places(myLinks.parentIndex)) @Uncounted async {
-	                            waitForParentToReceive();
-	                            val rootDstOffset = (Team.state(teamidcopy).local_parentIndex == -1) ? Team.state(teamidcopy).local_dst_off: 0;
-	                            val parentOffset = (Team.state(teamidcopy).local_parentIndex == -1) ? 0:Team.state(teamidcopy).local_offset;
-	                            val myOffset = childOffset - parentOffset + rootDstOffset;
-	                            Rail.uncountedCopy(grTmp, 0, Team.state(teamidcopy).local_temp_buff as Rail[T], myOffset, childTotalData, incrementParentPhase);
+	                            if (waitForParentToReceive()){
+	                                val rootDstOffset = (Team.state(teamidcopy).local_parentIndex == -1) ? Team.state(teamidcopy).local_dst_off: 0;
+	                                val parentOffset = (Team.state(teamidcopy).local_parentIndex == -1) ? 0:Team.state(teamidcopy).local_offset;
+	                                val myOffset = childOffset - parentOffset + rootDstOffset;
+	                                Rail.uncountedCopy(grTmp, 0, Team.state(teamidcopy).local_temp_buff as Rail[T], myOffset, childTotalData, incrementParentPhase);
+	                            }
 	                        }
 	                        grTmp.forget();
 	                    }
 	                } else {
 	                    at (places(myLinks.parentIndex)) @Uncounted async { 
-	                        waitForParentToReceive();
-	                        incrementParentPhase();
+	                        if (waitForParentToReceive()){
+	                            incrementParentPhase();
+	                        }
 	                    }
 	                }
 	                

--- a/x10.runtime/src-x10/x10/util/Team.x10
+++ b/x10.runtime/src-x10/x10/util/Team.x10
@@ -1118,7 +1118,7 @@ public struct Team {
             // note that local indexes are not yet set up, so we won't check for dead places in this call
             sleepUntil(() => this.phase.compareAndSet(PHASE_READY, PHASE_INIT));
             
-            //// commented to allow the place to notify its children with the invalid team status before leaving the collection
+            //// commented to allow the place to notify its children with the invalid team status before leaving the collective
             //// don't do anything if this team was previously set to invalid
             //if (!Team.state(this.teamid).isValid)
             //    throw new DeadPlaceException("Team "+this.teamid+" contains at least one dead member");

--- a/x10.tests/tests/MicroBenchmarks/ResilientAllreduceTest.x10
+++ b/x10.tests/tests/MicroBenchmarks/ResilientAllreduceTest.x10
@@ -1,0 +1,124 @@
+/*
+ *  This file is part of the X10 project (http://x10-lang.org).
+ *
+ *  This file is licensed to You under the Eclipse Public License (EPL);
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      http://www.opensource.org/licenses/eclipse-1.0.php
+ *
+ *  (C) Copyright IBM Corporation 2014-2015.
+ */
+import harness.x10Test;
+
+import x10.util.Team;
+
+/**
+ * Benchmarks performance of Team.allreduce for varying data size
+ */
+public class ResilientAllreduceTest extends x10Test {
+    private static SIZE = 2<<19;
+    private val victim:Long;
+
+    public def this(victimPlace:Long){
+        this.victim = victimPlace;
+    }
+    
+	public def run(): Boolean {
+        try{
+            finish for (place in Place.places()) at (place) async {
+            
+                if (here.id == victim){
+                    async System.killHere();
+                }
+                val src = new Rail[Double](SIZE, (i:Long) => i as Double);
+                val dst = new Rail[Double](SIZE);
+                val start = System.nanoTime();
+            
+                Team.WORLD.allreduce(src, 0, dst, 0, SIZE, Team.ADD);     
+             }
+        } catch(dpe:DeadPlaceException){
+            Console.OUT.println("All reduce failed with a dead place exception ...");
+        } catch (me:MultipleExceptions) {
+            val dper = me.getExceptionsOfType[DeadPlaceException]();
+            if (dper.size > 0)
+                Console.OUT.println("All reduce failed with a dead place exception ...");
+        }
+        return true;
+	}
+
+	public static def main(var args: Rail[String]): void {
+        var victimPlace:Long = 1;
+        if (args.size > 0) {
+            victimPlace = Long.parse(args(0));
+        }
+		new ResilientAllreduceTest(victimPlace).execute();
+	}
+}
+
+/*
+x10c++ -sourcepath ../x10lib/ ResilientAllreduceTest.x10 -o ResilientAllreduceTest.sock
+X10_TEAM_DEBUG_INTERNALS=1 X10_RESILIENT_MODE=1 X10_NPLACES=6 ./ResilientAllreduceTest.sock 2
+
+=> sometimes the program hangs
+
+Place(1):team0 entered AllReduce phase=0, root=Place(0)
+Place(1) getLinks called with myIndex=1 parent=-1 startIndex=0, endIndex=5
+Place(1) getLinks called with myIndex=1 parent=0 startIndex=1, endIndex=2
+Place(1):team0, root=Place(0) has parent Place(0)
+Place(1):team0, root=Place(0) has children Place(2), Place(-1)
+Place(1):team0 waiting for children phase 3
+Place(2):team0 entered AllReduce phase=0, root=Place(0)
+Place(3):team0 entered AllReduce phase=0, root=Place(0)
+Place(3) getLinks called with myIndex=3 parent=-1 startIndex=0, endIndex=5
+Place(3) getLinks called with myIndex=3 parent=0 startIndex=3, endIndex=5
+Place(3):team0, root=Place(0) has parent Place(0)
+Place(3):team0, root=Place(0) has children Place(4), Place(5)
+Place(3):team0 waiting for children phase 2
+Place(2) getLinks called with myIndex=2 parent=-1 startIndex=0, endIndex=5
+Place(2) getLinks called with myIndex=2 parent=0 startIndex=1, endIndex=2
+Place(2) getLinks called with myIndex=2 parent=1 startIndex=2, endIndex=2
+Place(2):team0, root=Place(0) has parent Place(1)
+Place(2):team0, root=Place(0) has children Place(-1), Place(-1)
+Place(2):team0 waiting for children phase 4
+Place(2):team0 released by children phase 4
+Place(2) moving data to parent
+Place(2) waiting for parent Place(1):team0 to release us from phase 4
+Place(1) parent ready to receive phase 3
+Place(4):team0 entered AllReduce phase=0, root=Place(0)
+Place(4) getLinks called with myIndex=4 parent=-1 startIndex=0, endIndex=5
+Place(4) getLinks called with myIndex=4 parent=0 startIndex=3, endIndex=5
+Place(4) getLinks called with myIndex=4 parent=3 startIndex=4, endIndex=4
+Place(4):team0, root=Place(0) has parent Place(3)
+Place(4):team0, root=Place(0) has children Place(-1), Place(-1)
+Place(4):team0 waiting for children phase 4
+Place(4):team0 released by children phase 4
+Place(4) moving data to parent
+Place(4) waiting for parent Place(3):team0 to release us from phase 4
+
+Place 2 exited unexpectedly with exit code: 1
+
+Place(5):team0 entered AllReduce phase=0, root=Place(0)
+Place(5) getLinks called with myIndex=5 parent=-1 startIndex=0, endIndex=5
+Place(5) getLinks called with myIndex=5 parent=0 startIndex=3, endIndex=5
+Place(5) getLinks called with myIndex=5 parent=3 startIndex=5, endIndex=5
+Place(5):team0, root=Place(0) has parent Place(3)
+Place(5):team0, root=Place(0) has children Place(-1), Place(-1)
+Place(5):team0 waiting for children phase 4
+Place(5):team0 released by children phase 4
+Place(5) moving data to parent
+Place(5) waiting for parent Place(3):team0 to release us from phase 4
+Place(3) parent ready to receive phase 2
+Place(3) parent ready to receive phase 2
+Place(0):team0 entered AllReduce phase=0, root=Place(0)
+Place(0) getLinks called with myIndex=0 parent=-1 startIndex=0, endIndex=5
+Place(0):team0, root=Place(0) has parent Place(-1)
+Place(0):team0, root=Place(0) has children Place(1), Place(3)
+Place(0):team0 waiting for children phase 2
+Place(3):team0 released by children phase 4
+Place(3) moving data to parent
+Place(3) waiting for parent Place(0):team0 to release us from phase 4
+Place(0) parent ready to receive phase 2
+
+==> hang
+
+*/


### PR DESCRIPTION
Fixing segmentation fault and hanging issues in Team when places fail.
Modified sleepUntil and waitForParentToReceive to return the team status, and used the return value to avoid moving data to a failed place , and to terminate the collective when needed.

The fix is not complete, sleepUntil still hangs in some cases. The new class ResilientAllreduceTest includes a sample log for a hanging scenario.

