### PR TITLE
propagate the ULFM collective failure to the parent finish

### DIFF
--- a/x10.runtime/src-cpp/x10aux/network.cc
+++ b/x10.runtime/src-cpp/x10aux/network.cc
@@ -462,8 +462,8 @@ void x10aux::coll_handler(void *arg) {
     x10::xrx::FinishState* fs = (x10::xrx::FinishState*)arg;
     fs->notifyActivityTermination();
 }
-
-void x10aux::res_coll_handler(void *arg) {
+//used with ULFM, called only when a collective has failed due to a process failure
+void x10aux::failed_coll_handler(void *arg) {
     x10::xrx::FinishState* fs = (x10::xrx::FinishState*)arg;
     fs->notifyActivityTermination();
     x10::xrx::Runtime::notifyPlaceDeath();

--- a/x10.runtime/src-cpp/x10aux/network.cc
+++ b/x10.runtime/src-cpp/x10aux/network.cc
@@ -463,6 +463,12 @@ void x10aux::coll_handler(void *arg) {
     fs->notifyActivityTermination();
 }
 
+void x10aux::res_coll_handler(void *arg) {
+    x10::xrx::FinishState* fs = (x10::xrx::FinishState*)arg;
+    fs->notifyActivityTermination();
+    x10::xrx::Runtime::notifyPlaceDeath();
+}
+
 struct pointer_pair {
     void *fst;
     void *snd;

--- a/x10.runtime/src-cpp/x10aux/network.h
+++ b/x10.runtime/src-cpp/x10aux/network.h
@@ -204,6 +204,8 @@ namespace x10aux {
     void coll_handler(void *arg);
     void *coll_enter2(void *arg);
     void coll_handler2(x10rt_team t, void *arg);
+    
+    void res_coll_handler(void *arg);
 }
 #endif
 // vim:tabstop=4:shiftwidth=4:expandtab

--- a/x10.runtime/src-cpp/x10aux/network.h
+++ b/x10.runtime/src-cpp/x10aux/network.h
@@ -205,7 +205,7 @@ namespace x10aux {
     void *coll_enter2(void *arg);
     void coll_handler2(x10rt_team t, void *arg);
     
-    void res_coll_handler(void *arg);
+    void failed_coll_handler(void *arg);
 }
 #endif
 // vim:tabstop=4:shiftwidth=4:expandtab

--- a/x10.runtime/src-java/x10/x10rt/TeamSupport.java
+++ b/x10.runtime/src-java/x10/x10rt/TeamSupport.java
@@ -197,8 +197,9 @@ public class TeamSupport {
         }
     }
     
-    public static void nativeAllReduce(int id, int role, Rail<?> src, int src_off, 
+    public static boolean nativeAllReduce(int id, int role, Rail<?> src, int src_off, 
                                        Rail<?> dst, int dst_off, int count, int op) {
+    	boolean success = true;
         if (!X10RT.forceSinglePlace) {
         int typeCode = getTypeCode(src);
         Object srcRaw = typeCode == RED_TYPE_COMPLEX ? copyComplexToNewDouble(src, src_off, count) : src.getBackingArray();
@@ -209,11 +210,12 @@ public class TeamSupport {
         FinishState fs = ActivityManagement.activityCreationBookkeeping();
 
         try {
-            nativeAllReduceImpl(id, role, srcRaw, src_off, dstRaw, dst_off, count, op, typeCode, fs);
+            success = nativeAllReduceImpl(id, role, srcRaw, src_off, dstRaw, dst_off, count, op, typeCode, fs);
         } catch (UnsatisfiedLinkError e) {
             aboutToDie("nativeAllReduce");
         }
         }
+        return success;
     }
 
     public static void nativeIndexOfMax(int id, int role, Rail<?> src,
@@ -304,7 +306,7 @@ public class TeamSupport {
                                                    Object dstRaw, int dst_off,
                                                    int count, int op, int typecode, FinishState fs);
 
-    private static native void nativeAllReduceImpl(int id, int role, Object srcRaw, int src_off, 
+    private static native Boolean nativeAllReduceImpl(int id, int role, Object srcRaw, int src_off, 
                                                    Object dstRaw, int dst_off,
                                                    int count, int op, int typecode, FinishState fs);
     

--- a/x10.runtime/src-x10/x10/util/Team.x10
+++ b/x10.runtime/src-x10/x10/util/Team.x10
@@ -709,7 +709,7 @@ public struct Team {
     }
 
     @Native("java", "x10.x10rt.TeamSupport.nativeAllReduce(#id, #role, #src, #src_off, #dst, #dst_off, #count, #op)")
-    @Native("c++", "x10rt_allreduce(#id, #role, &(#src)->raw[#src_off], &(#dst)->raw[#dst_off], (x10rt_red_op_type)(#op), x10rt_get_red_type<TPMGL(T)>(), #count, ::x10aux::res_coll_handler, ::x10aux::coll_handler,::x10aux::coll_enter())")
+    @Native("c++", "x10rt_allreduce(#id, #role, &(#src)->raw[#src_off], &(#dst)->raw[#dst_off], (x10rt_red_op_type)(#op), x10rt_get_red_type<TPMGL(T)>(), #count, ::x10aux::failed_coll_handler, ::x10aux::coll_handler,::x10aux::coll_enter())")
     private static def nativeAllreduce[T](id:Int, role:Int, src:Rail[T], src_off:Int, dst:Rail[T], dst_off:Int, count:Int, op:Int):Boolean = false;
 
     /** Performs a reduction on a single value, returning the result */
@@ -799,7 +799,7 @@ public struct Team {
 
     private static def nativeAllreduce[T](id:Int, role:Int, src:Rail[T], dst:Rail[T], op:Int) : void {
         @Native("java", "x10.x10rt.TeamSupport.nativeAllReduce(id, role, src, 0, dst, 0, 1, op);")
-        @Native("c++", "x10rt_allreduce(id, role, src->raw, dst->raw, (x10rt_red_op_type)op, x10rt_get_red_type<TPMGL(T)>(), 1, ::x10aux::res_coll_handler, ::x10aux::coll_handler, ::x10aux::coll_enter());") {}
+        @Native("c++", "x10rt_allreduce(id, role, src->raw, dst->raw, (x10rt_red_op_type)op, x10rt_get_red_type<TPMGL(T)>(), 1, ::x10aux::failed_coll_handler, ::x10aux::coll_handler, ::x10aux::coll_enter());") {}
     }
 
     /** This operation blocks until all members have received the computed result.  
@@ -826,7 +826,7 @@ public struct Team {
 
     private static def nativeIndexOfMax(id:Int, role:Int, src:Rail[DoubleIdx], dst:Rail[DoubleIdx]) : void {
         @Native("java", "x10.x10rt.TeamSupport.nativeIndexOfMax(id, role, src, dst);")
-        @Native("c++", "x10rt_allreduce(id, role, src->raw, dst->raw, X10RT_RED_OP_MAX, X10RT_RED_TYPE_DBL_S32, 1, ::x10aux::res_coll_handler, ::x10aux::coll_handler, ::x10aux::coll_enter());") {}
+        @Native("c++", "x10rt_allreduce(id, role, src->raw, dst->raw, X10RT_RED_OP_MAX, X10RT_RED_TYPE_DBL_S32, 1, ::x10aux::failed_coll_handler, ::x10aux::coll_handler, ::x10aux::coll_enter());") {}
     }
 
     /** This operation blocks until all members have received the computed result.  
@@ -853,7 +853,7 @@ public struct Team {
 
     private static def nativeIndexOfMin(id:Int, role:Int, src:Rail[DoubleIdx], dst:Rail[DoubleIdx]) : void {
         @Native("java", "x10.x10rt.TeamSupport.nativeIndexOfMin(id, role, src, dst);")
-        @Native("c++", "x10rt_allreduce(id, role, src->raw, dst->raw, X10RT_RED_OP_MIN, X10RT_RED_TYPE_DBL_S32, 1, ::x10aux::res_coll_handler, ::x10aux::coll_handler, ::x10aux::coll_enter());") {}
+        @Native("c++", "x10rt_allreduce(id, role, src->raw, dst->raw, X10RT_RED_OP_MIN, X10RT_RED_TYPE_DBL_S32, 1, ::x10aux::failed_coll_handler, ::x10aux::coll_handler, ::x10aux::coll_enter());") {}
     }
 
     /** Create new teams by subdividing an existing team.  This is called by each member

--- a/x10.runtime/src-x10/x10/util/Team.x10
+++ b/x10.runtime/src-x10/x10/util/Team.x10
@@ -698,7 +698,9 @@ public struct Team {
             if (DEBUG) Runtime.println(here + " entering pre-allreduce barrier on team "+id);
             barrier();
             if (DEBUG) Runtime.println(here + " entering native allreduce on team "+id);
-            nativeAllreduce(id, id==0n?here.id() as Int:Team.roles(id), src, src_off as Int, dst, dst_off as Int, count as Int, op);
+            val success = nativeAllreduce(id, id==0n?here.id() as Int:Team.roles(id), src, src_off as Int, dst, dst_off as Int, count as Int, op);
+            if (!success)
+                throw new DeadPlaceException("[Native] Team "+id+" contains at least one dead member");
         } else {
             if (DEBUG) Runtime.println(here + " entering Team.x10 allreduce on team "+id);
             state(id).collective_impl[T](LocalTeamState.COLL_ALLREDUCE, state(id).places(0), src, src_off, dst, dst_off, count, op, null, null);
@@ -706,10 +708,9 @@ public struct Team {
         if (DEBUG) Runtime.println(here + " Finished allreduce on team "+id);
     }
 
-    private static def nativeAllreduce[T](id:Int, role:Int, src:Rail[T], src_off:Int, dst:Rail[T], dst_off:Int, count:Int, op:Int) : void {
-        @Native("java", "x10.x10rt.TeamSupport.nativeAllReduce(id, role, src, src_off, dst, dst_off, count, op);")
-        @Native("c++", "x10rt_allreduce(id, role, &src->raw[src_off], &dst->raw[dst_off], (x10rt_red_op_type)op, x10rt_get_red_type<TPMGL(T)>(), count, ::x10aux::coll_handler, ::x10aux::coll_enter());") {}
-    }
+    @Native("java", "x10.x10rt.TeamSupport.nativeAllReduce(#id, #role, #src, #src_off, #dst, #dst_off, #count, #op)")
+    @Native("c++", "x10rt_allreduce(#id, #role, &(#src)->raw[#src_off], &(#dst)->raw[#dst_off], (x10rt_red_op_type)(#op), x10rt_get_red_type<TPMGL(T)>(), #count, ::x10aux::res_coll_handler, ::x10aux::coll_handler,::x10aux::coll_enter())")
+    private static def nativeAllreduce[T](id:Int, role:Int, src:Rail[T], src_off:Int, dst:Rail[T], dst_off:Int, count:Int, op:Int):Boolean = false;
 
     /** Performs a reduction on a single value, returning the result */
     public def allreduce (src:Boolean, op:Int):Boolean {
@@ -798,7 +799,7 @@ public struct Team {
 
     private static def nativeAllreduce[T](id:Int, role:Int, src:Rail[T], dst:Rail[T], op:Int) : void {
         @Native("java", "x10.x10rt.TeamSupport.nativeAllReduce(id, role, src, 0, dst, 0, 1, op);")
-        @Native("c++", "x10rt_allreduce(id, role, src->raw, dst->raw, (x10rt_red_op_type)op, x10rt_get_red_type<TPMGL(T)>(), 1, ::x10aux::coll_handler, ::x10aux::coll_enter());") {}
+        @Native("c++", "x10rt_allreduce(id, role, src->raw, dst->raw, (x10rt_red_op_type)op, x10rt_get_red_type<TPMGL(T)>(), 1, ::x10aux::res_coll_handler, ::x10aux::coll_handler, ::x10aux::coll_enter());") {}
     }
 
     /** This operation blocks until all members have received the computed result.  
@@ -825,7 +826,7 @@ public struct Team {
 
     private static def nativeIndexOfMax(id:Int, role:Int, src:Rail[DoubleIdx], dst:Rail[DoubleIdx]) : void {
         @Native("java", "x10.x10rt.TeamSupport.nativeIndexOfMax(id, role, src, dst);")
-        @Native("c++", "x10rt_allreduce(id, role, src->raw, dst->raw, X10RT_RED_OP_MAX, X10RT_RED_TYPE_DBL_S32, 1, ::x10aux::coll_handler, ::x10aux::coll_enter());") {}
+        @Native("c++", "x10rt_allreduce(id, role, src->raw, dst->raw, X10RT_RED_OP_MAX, X10RT_RED_TYPE_DBL_S32, 1, ::x10aux::res_coll_handler, ::x10aux::coll_handler, ::x10aux::coll_enter());") {}
     }
 
     /** This operation blocks until all members have received the computed result.  
@@ -852,7 +853,7 @@ public struct Team {
 
     private static def nativeIndexOfMin(id:Int, role:Int, src:Rail[DoubleIdx], dst:Rail[DoubleIdx]) : void {
         @Native("java", "x10.x10rt.TeamSupport.nativeIndexOfMin(id, role, src, dst);")
-        @Native("c++", "x10rt_allreduce(id, role, src->raw, dst->raw, X10RT_RED_OP_MIN, X10RT_RED_TYPE_DBL_S32, 1, ::x10aux::coll_handler, ::x10aux::coll_enter());") {}
+        @Native("c++", "x10rt_allreduce(id, role, src->raw, dst->raw, X10RT_RED_OP_MIN, X10RT_RED_TYPE_DBL_S32, 1, ::x10aux::res_coll_handler, ::x10aux::coll_handler, ::x10aux::coll_enter());") {}
     }
 
     /** Create new teams by subdividing an existing team.  This is called by each member

--- a/x10.runtime/x10rt/common/x10rt_front.cc
+++ b/x10.runtime/x10rt/common/x10rt_front.cc
@@ -263,14 +263,15 @@ void x10rt_reduce (x10rt_team team, x10rt_place role,
     x10rt_lgl_reduce(team, role, root, sbuf, dbuf, op, dtype, count, ch, arg);
 }
 
-void x10rt_allreduce (x10rt_team team, x10rt_place role,
+bool x10rt_allreduce (x10rt_team team, x10rt_place role,
                       const void *sbuf, void *dbuf,
                       x10rt_red_op_type op, 
                       x10rt_red_type dtype,
                       size_t count,
+                      x10rt_completion_handler *errch,
                       x10rt_completion_handler *ch, void *arg)
 {
-    x10rt_lgl_allreduce(team, role, sbuf, dbuf, op, dtype, count, ch, arg);
+    return x10rt_lgl_allreduce(team, role, sbuf, dbuf, op, dtype, count, errch, ch, arg);
 }
 
 

--- a/x10.runtime/x10rt/common/x10rt_logical.cc
+++ b/x10.runtime/x10rt/common/x10rt_logical.cc
@@ -30,6 +30,7 @@
 #include <x10rt_front.h>
 
 #define ESCAPE_IF_ERR if (g.error_code != X10RT_ERR_OK) return; else { }
+#define ESCAPE_IF_ERR_BOOL if (g.error_code != X10RT_ERR_OK) return false; else { }
 #define CHECK_ERR_AND_RETURN if (g.error_code != X10RT_ERR_OK) return g.error_code; else { }
 
 #define PROP_ERR(x, y) do { \
@@ -1160,18 +1161,20 @@ void x10rt_lgl_reduce (x10rt_team team, x10rt_place role,
     }
 }
 
-void x10rt_lgl_allreduce (x10rt_team team, x10rt_place role,
+bool x10rt_lgl_allreduce (x10rt_team team, x10rt_place role,
                           const void *sbuf, void *dbuf,
                           x10rt_red_op_type op, 
                           x10rt_red_type dtype,
                           size_t count,
+                          x10rt_completion_handler *errch,
                           x10rt_completion_handler *ch, void *arg)
 {
-    ESCAPE_IF_ERR;
+	ESCAPE_IF_ERR_BOOL;
     if (has_collectives >= X10RT_COLL_ALLBLOCKINGCOLLECTIVES) {
-        x10rt_net_allreduce(team, role, sbuf, dbuf, op, dtype, count, ch, arg);
+        return x10rt_net_allreduce(team, role, sbuf, dbuf, op, dtype, count, errch, ch, arg);
     } else {
         x10rt_emu_reduce(team, role, 0, sbuf, dbuf, op, dtype, count, ch, arg, true);
         while (x10rt_emu_coll_probe());
+        return true; //TODO: should not always return true, but x10rt_emu_reduce is not used
     }
 }

--- a/x10.runtime/x10rt/include/x10rt_front.h
+++ b/x10.runtime/x10rt/include/x10rt_front.h
@@ -934,11 +934,12 @@ X10RT_C void x10rt_reduce (x10rt_team team, x10rt_place role,
  *
  * \param arg User pointer that is passed to the completion handler
  */
-X10RT_C void x10rt_allreduce (x10rt_team team, x10rt_place role,
+X10RT_C bool x10rt_allreduce (x10rt_team team, x10rt_place role,
                               const void *sbuf, void *dbuf,
                               x10rt_red_op_type op,
                               x10rt_red_type dtype,
                               size_t count,
+                              x10rt_completion_handler *errch,
                               x10rt_completion_handler *ch, void *arg);
 
 /** Sets arg to 1.

--- a/x10.runtime/x10rt/include/x10rt_logical.h
+++ b/x10.runtime/x10rt/include/x10rt_logical.h
@@ -510,11 +510,12 @@ X10RT_C void x10rt_lgl_reduce (x10rt_team team, x10rt_place role,
  * \param ch As in #x10rt_allreduce
  * \param arg As in #x10rt_allreduce
  */
-X10RT_C void x10rt_lgl_allreduce (x10rt_team team, x10rt_place role,
+X10RT_C bool x10rt_lgl_allreduce (x10rt_team team, x10rt_place role,
                                   const void *sbuf, void *dbuf,
                                   x10rt_red_op_type op,
                                   x10rt_red_type dtype,
                                   size_t count,
+                                  x10rt_completion_handler *errch,
                                   x10rt_completion_handler *ch, void *arg);
 
 #endif

--- a/x10.runtime/x10rt/include/x10rt_net.h
+++ b/x10.runtime/x10rt/include/x10rt_net.h
@@ -354,11 +354,12 @@ X10RT_C void x10rt_net_reduce (x10rt_team team, x10rt_place role,
  * \param ch As in #x10rt_lgl_allreduce
  * \param arg As in #x10rt_lgl_allreduce
  */
-X10RT_C void x10rt_net_allreduce (x10rt_team team, x10rt_place role,
+X10RT_C bool x10rt_net_allreduce (x10rt_team team, x10rt_place role,
                                   const void *sbuf, void *dbuf,
                                   x10rt_red_op_type op,
                                   x10rt_red_type dtype,
                                   size_t count,
+                                  x10rt_completion_handler *errch,
                                   x10rt_completion_handler *ch, void *arg);
 
 /** Counters exposed to the backend for direct (i.e. fast) manipulation.

--- a/x10.runtime/x10rt/jni/jni_team.cc
+++ b/x10.runtime/x10rt/jni/jni_team.cc
@@ -854,7 +854,7 @@ JNIEXPORT void JNICALL Java_x10_x10rt_TeamSupport_nativeReduceImpl(JNIEnv *env, 
  * Method:    nativeAllReduceImpl
  * Signature: (IILjava/lang/Object;ILjava/lang/Object;IIIILx10/lang/FinishState;)V
  */
-JNIEXPORT void JNICALL Java_x10_x10rt_TeamSupport_nativeAllReduceImpl(JNIEnv *env, jclass klazz,
+JNIEXPORT jobject JNICALL Java_x10_x10rt_TeamSupport_nativeAllReduceImpl(JNIEnv *env, jclass klazz,
                                                                       jint id, jint role,
                                                                       jobject src, jint src_off,
                                                                       jobject dst, jint dst_off,
@@ -954,8 +954,9 @@ JNIEXPORT void JNICALL Java_x10_x10rt_TeamSupport_nativeAllReduceImpl(JNIEnv *en
     callbackArg->srcData = srcData;
     callbackArg->dstData = dstData;
 
-    x10rt_allreduce(id, role, srcData, dstData, (x10rt_red_op_type)op, (x10rt_red_type)typecode,
-                    count, &postCopyCallback, callbackArg);
+    //FIXME: how to call the correct failure call back?
+    return (jobject) x10rt_allreduce(id, role, srcData, dstData, (x10rt_red_op_type)op, (x10rt_red_type)typecode,
+                    count, &postCopyCallback, &postCopyCallback, callbackArg);
 }
 
 
@@ -1023,7 +1024,7 @@ static void indexOfImpl(JNIEnv *env, jint id, jint role,
     callbackArg->srcData = srcData;
     callbackArg->dstData = dstData;
 
-    x10rt_allreduce(id, role, srcData, dstData, op, X10RT_RED_TYPE_DBL_S32, 1, &minmaxCallback, callbackArg);
+    x10rt_allreduce(id, role, srcData, dstData, op, X10RT_RED_TYPE_DBL_S32, 1, &minmaxCallback, &minmaxCallback, callbackArg);
 }
 
 

--- a/x10.runtime/x10rt/pami/x10rt_pami.cc
+++ b/x10.runtime/x10rt/pami/x10rt_pami.cc
@@ -2198,8 +2198,8 @@ void x10rt_net_reduce (x10rt_team team, x10rt_place role,
 	if (status != PAMI_SUCCESS) error("Unable to post a reduce on team %u", team);
 }
 
-void x10rt_net_allreduce (x10rt_team team, x10rt_place role, const void *sbuf, void *dbuf,
-		x10rt_red_op_type op, x10rt_red_type dtype, size_t count, x10rt_completion_handler *ch, void *arg)
+bool x10rt_net_allreduce (x10rt_team team, x10rt_place role, const void *sbuf, void *dbuf,
+		x10rt_red_op_type op, x10rt_red_type dtype, size_t count, x10rt_completion_handler *errch, x10rt_completion_handler *ch, void *arg)
 {
 	// Issue the collective
 	x10rt_pami_team_callback *tcb = (x10rt_pami_team_callback *)x10rt_malloc(sizeof(x10rt_pami_team_callback));
@@ -2242,4 +2242,5 @@ void x10rt_net_allreduce (x10rt_team team, x10rt_place role, const void *sbuf, v
 	PAMI_Context_unlock(state.context);
 #endif
 	if (status != PAMI_SUCCESS) error("Unable to post an allreduce on team %u", team);
+    return true; //PAMI is not resilient, always return true
 }

--- a/x10.runtime/x10rt/sockets/x10rt_sockets.cc
+++ b/x10.runtime/x10rt/sockets/x10rt_sockets.cc
@@ -1531,10 +1531,11 @@ void x10rt_net_reduce (x10rt_team team, x10rt_place role,
 	fatal_error("x10rt_net_reduce not implemented");
 }
 
-void x10rt_net_allreduce (x10rt_team team, x10rt_place role, const void *sbuf, void *dbuf,
-		x10rt_red_op_type op, x10rt_red_type dtype, size_t count, x10rt_completion_handler *ch, void *arg)
+bool x10rt_net_allreduce (x10rt_team team, x10rt_place role, const void *sbuf, void *dbuf,
+		x10rt_red_op_type op, x10rt_red_type dtype, size_t count,x10rt_completion_handler *errch, x10rt_completion_handler *ch, void *arg)
 {
 	fatal_error("x10rt_net_allreduce not implemented");
+	return false;
 }
 
 const char *x10rt_net_error_msg (void) { return context.errorMsg; }

--- a/x10.runtime/x10rt/standalone/x10rt_standalone.cc
+++ b/x10.runtime/x10rt/standalone/x10rt_standalone.cc
@@ -1030,11 +1030,12 @@ void x10rt_net_reduce (x10rt_team team, x10rt_place role,
 	abort();
 }
 
-void x10rt_net_allreduce (x10rt_team team, x10rt_place role,
+bool x10rt_net_allreduce (x10rt_team team, x10rt_place role,
                           const void *sbuf, void *dbuf,
                           x10rt_red_op_type op, 
                           x10rt_red_type dtype,
                           size_t count,
+                          x10rt_completion_handler *errch,
                           x10rt_completion_handler *ch, void *arg)
 {
     abort();

--- a/x10.runtime/x10rt/test/x10rt_coll.cc
+++ b/x10.runtime/x10rt/test/x10rt_coll.cc
@@ -318,6 +318,7 @@ static void coll_test (x10rt_team team, x10rt_place role, x10rt_place per_place)
             std::cout<<team<<": allreduce correctness (if no errors then OK):" << std::endl;
         finished = 0;
         x10rt_allreduce(team, role, sbuf, dbuf, X10RT_RED_OP_ADD, X10RT_RED_TYPE_FLT, count,
+        		            x10rt_one_setter,
                             x10rt_one_setter, &finished);
         while (!finished) { x10rt_aborting_probe(); }
         float oracle_base = (x10rt_team_sz(team)*x10rt_team_sz(team) + x10rt_team_sz(team))/2;
@@ -337,7 +338,7 @@ static void coll_test (x10rt_team team, x10rt_place role, x10rt_place per_place)
         for (int i=0 ; i<long_tests ; ++i) {
             finished = 0;
             x10rt_allreduce(team, role, sbuf, dbuf, X10RT_RED_OP_ADD, X10RT_RED_TYPE_FLT, count,
-                                x10rt_one_setter, &finished);
+                                x10rt_one_setter, x10rt_one_setter, &finished);
             while (!finished) { sched_yield(); x10rt_aborting_probe(); }
         }
         taken += nano_time();


### PR DESCRIPTION
Changes to propagate the process failure from ULFM to the x10 runtime. 
The changes are done only for the allreduce collective.