### PR TITLE
Propagate ULFM collective errors to Team (appends to Pull Request #5)

### DIFF
--- a/x10.runtime/src-cpp/x10/lang/RuntimeNatives.cc
+++ b/x10.runtime/src-cpp/x10/lang/RuntimeNatives.cc
@@ -13,6 +13,7 @@
 
 #include <cstdlib>
 #include <cstdio>
+#include <unistd.h>
 
 #ifdef __bg__
 #ifndef DISABLE_CLOCK_GETTIME
@@ -58,6 +59,7 @@
 #include <x10/io/InputStreamReader__InputStream.h>
 #include <x10/io/OutputStreamWriter.h>
 #include <x10/io/OutputStreamWriter__OutputStream.h>
+#include <signal.h>
 
 using namespace x10::lang;
 using namespace x10::io;
@@ -65,7 +67,11 @@ using namespace x10::io;
 
 void RuntimeNatives::exit(x10_int code) {
 	// exit now, using this exit code
-	::exit(code);
+	char* exit_mode = getenv("X10_EXIT_BY_SIGKILL");
+	if (exit_mode && atoi(exit_mode) == 1)
+		::kill(getpid(), SIGKILL);
+	else
+		::exit(code);
 }
 
 x10_long RuntimeNatives::currentTimeMillis() {

--- a/x10.runtime/src-java/x10/x10rt/TeamSupport.java
+++ b/x10.runtime/src-java/x10/x10rt/TeamSupport.java
@@ -140,8 +140,9 @@ public class TeamSupport {
         }
     }
         
-    public static void nativeBcast(int id, int role, int root, Rail<?> src, int src_off, 
+    public static boolean nativeBcast(int id, int role, int root, Rail<?> src, int src_off, 
                                    Rail<?> dst, int dst_off, int count) {
+    	boolean success = true;
         if (!X10RT.forceSinglePlace) {
         int typeCode = getTypeCode(src);
         assert getTypeCode(dst) == typeCode : "Incompatible src and dst arrays";
@@ -152,11 +153,12 @@ public class TeamSupport {
         FinishState fs = ActivityManagement.activityCreationBookkeeping();
 
         try {
-            nativeBcastImpl(id, role, root, srcRaw, src_off, dstRaw, dst_off, count, typeCode, fs);
+        	success =nativeBcastImpl(id, role, root, srcRaw, src_off, dstRaw, dst_off, count, typeCode, fs);
         } catch (UnsatisfiedLinkError e) {
             aboutToDie("nativeBcast");
         }
         }
+        return success;
     }
 
     public static void nativeAllToAll(int id, int role, Rail<?> src, int src_off, 
@@ -294,7 +296,7 @@ public class TeamSupport {
                                                  Object dstRaw, int dst_off,
                                                  int count, int typecode, FinishState fs);
     
-    private static native void nativeBcastImpl(int id, int role, int root, Object srcRaw, int src_off, 
+    private static native Boolean nativeBcastImpl(int id, int role, int root, Object srcRaw, int src_off, 
                                                Object dstRaw, int dst_off,
                                                int count, int typecode, FinishState fs);
     

--- a/x10.runtime/src-x10/x10/util/Team.x10
+++ b/x10.runtime/src-x10/x10/util/Team.x10
@@ -270,19 +270,21 @@ public struct Team {
     	if (collectiveSupportLevel == X10RT_COLL_ALLNONBLOCKINGCOLLECTIVES)
     		finish nativeScatterv(id, my_role, root.id() as Int, src, src_off as Int, scounts, soffsets, dst, dst_off as Int);
     	else if (collectiveSupportLevel == X10RT_COLL_ALLBLOCKINGCOLLECTIVES || collectiveSupportLevel == X10RT_COLL_NONBLOCKINGBARRIER) {
-    		barrier();
-    		nativeScatterv(id, my_role, root.id() as Int, src, src_off as Int, scounts, soffsets, dst, dst_off as Int);
+    	    barrier();
+    	    val success = nativeScatterv(id, my_role, root.id() as Int, src, src_off as Int, scounts, soffsets, dst, dst_off as Int);
+            if (!success)
+                throw new DeadPlaceException("[Native] Team "+id+" contains at least one dead member");
     	}
     	else{
     		state(id).collective_impl[T](LocalTeamState.COLL_SCATTERV, root, src, src_off, dst, dst_off, 0n, 0n, soffsets, scounts);
     	}
     }
     
-    //TODO: not supported for Java or PAMI
-    private static def nativeScatterv[T] (id:Int, role:Int, root:Int, src:Rail[T], src_off:Int, scounts:Rail[Int], soffsets:Rail[Int], dst:Rail[T], dst_off:Int) : void {        
-    	//@Native("java", "x10.x10rt.TeamSupport.nativeScatterv(id, role, root, ...);")
-    	@Native("c++", "x10rt_scatterv(id, role, root, src->raw, soffsets->raw, scounts->raw, &dst->raw[dst_off], scounts->raw[role], sizeof(TPMGL(T)), ::x10aux::coll_handler, ::x10aux::coll_enter());") {}
-    }
+    //TODO: not supported for Java
+    //@Native("java", "x10.x10rt.TeamSupport.nativeScatterv(id, role, root, ...);")
+    @Native("c++", "x10rt_scatterv(#id, #role, #root, #src->raw, #soffsets->raw, #scounts->raw, &(#dst)->raw[#dst_off], #scounts->raw[#role], sizeof(TPMGL(T)), ::x10aux::failed_coll_handler, ::x10aux::coll_handler, ::x10aux::coll_enter())")
+    private static def nativeScatterv[T] (id:Int, role:Int, root:Int, src:Rail[T], src_off:Int, scounts:Rail[Int], soffsets:Rail[Int], dst:Rail[T], dst_off:Int):Boolean = false;
+    
     
     //TODO: not supported for Java or PAMI
     public def gather[T] (root:Place, src:Rail[T], src_off:Long, dst:Rail[T], dst_off:Long, count:Long) : void {
@@ -336,18 +338,19 @@ public struct Team {
             finish nativeGatherv(id, my_role, root.id() as Int, src, src_off as Int, dst, dst_off as Int, dcounts, doffsets);
         else if (collectiveSupportLevel == X10RT_COLL_ALLBLOCKINGCOLLECTIVES || collectiveSupportLevel == X10RT_COLL_NONBLOCKINGBARRIER) {
             barrier();
-            nativeGatherv(id, my_role, root.id() as Int, src, src_off as Int, dst, dst_off as Int, dcounts, doffsets);
+            val success = nativeGatherv(id, my_role, root.id() as Int, src, src_off as Int, dst, dst_off as Int, dcounts, doffsets);
+            if (!success)
+                throw new DeadPlaceException("[Native] Team "+id+" contains at least one dead member");
         }
         else{
             state(id).collective_impl[T](LocalTeamState.COLL_GATHERV, root, src, src_off, dst, dst_off, 0n, 0n, doffsets, dcounts);
         }
     }
     
-    //TODO: not supported for Java or PAMI
-    private static def nativeGatherv[T] (id:Int, role:Int, root:Int, src:Rail[T], src_off:Int, dst:Rail[T], dst_off:Int, dcounts:Rail[Int], doffsets:Rail[Int]) : void {
-       //@Native("java", "x10.x10rt.TeamSupport.nativeGatherv(id, role, root, ...);")
-       @Native("c++", "x10rt_gatherv(id, role, root, &src->raw[src_off], dcounts->raw[role], dst->raw, doffsets->raw, dcounts->raw, sizeof(TPMGL(T)), ::x10aux::coll_handler, ::x10aux::coll_enter());") {}
-    }
+    //TODO: not supported for Java
+    //@Native("java", "x10.x10rt.TeamSupport.nativeGatherv(id, role, root, ...);")
+    @Native("c++", "x10rt_gatherv(#id, #role, #root, &(#src)->raw[#src_off], #dcounts->raw[#role], #dst->raw, #doffsets->raw, #dcounts->raw, sizeof(TPMGL(T)), ::x10aux::failed_coll_handler, ::x10aux::coll_handler, ::x10aux::coll_enter())")
+    private static def nativeGatherv[T] (id:Int, role:Int, root:Int, src:Rail[T], src_off:Int, dst:Rail[T], dst_off:Int, dcounts:Rail[Int], doffsets:Rail[Int]) : Boolean = false;
     
     /** Blocks until all members have received root's array.
      *
@@ -370,16 +373,17 @@ public struct Team {
             finish nativeBcast(id, id==0n?here.id() as Int:Team.roles(id), root.id() as Int, src, src_off as Int, dst, dst_off as Int, count as Int);
         else if (collectiveSupportLevel == X10RT_COLL_ALLBLOCKINGCOLLECTIVES || collectiveSupportLevel == X10RT_COLL_NONBLOCKINGBARRIER) {
             barrier();
-            nativeBcast(id, id==0n?here.id() as Int:Team.roles(id), root.id() as Int, src, src_off as Int, dst, dst_off as Int, count as Int);
+            val success = nativeBcast(id, id==0n?here.id() as Int:Team.roles(id), root.id() as Int, src, src_off as Int, dst, dst_off as Int, count as Int);
+            if (!success)
+                throw new DeadPlaceException("[Native] Team "+id+" contains at least one dead member");
         }
          else
              state(id).collective_impl[T](LocalTeamState.COLL_BROADCAST, root, src, src_off, dst, dst_off, count, 0n, null, null);
     }
 
-    private static def nativeBcast[T] (id:Int, role:Int, root:Int, src:Rail[T], src_off:Int, dst:Rail[T], dst_off:Int, count:Int) : void {
-        @Native("java", "x10.x10rt.TeamSupport.nativeBcast(id, role, root, src, src_off, dst, dst_off, count);")
-        @Native("c++", "x10rt_bcast(id, role, root, &src->raw[src_off], &dst->raw[dst_off], sizeof(TPMGL(T)), count, ::x10aux::coll_handler, ::x10aux::coll_enter());") {}
-    }
+    @Native("java", "x10.x10rt.TeamSupport.nativeBcast(#id, #role, #root, #src, #src_off, #dst, #dst_off, #count)")
+    @Native("c++", "x10rt_bcast(#id, #role, #root, &(#src)->raw[#src_off], &(#dst)->raw[#dst_off], sizeof(TPMGL(T)), #count, ::x10aux::failed_coll_handler, ::x10aux::coll_handler, ::x10aux::coll_enter())")
+    private static def nativeBcast[T] (id:Int, role:Int, root:Int, src:Rail[T], src_off:Int, dst:Rail[T], dst_off:Int, count:Int) : Boolean = false;
 
     /** Blocks until all members have received their part of each other member's array.
      * Each member receives a contiguous and distinct portion of the src array.

--- a/x10.runtime/x10rt/common/x10rt_emu_coll.cc
+++ b/x10.runtime/x10rt/common/x10rt_emu_coll.cc
@@ -831,10 +831,11 @@ void x10rt_emu_scatter (x10rt_team team, x10rt_place role,
     // 'run into' the current barrier causing race conditions
 }
 
-void  x10rt_emu_scatterv (x10rt_team team, x10rt_place role,
+bool  x10rt_emu_scatterv (x10rt_team team, x10rt_place role,
       	                  x10rt_place root, const void *sbuf,
       	                  const void *soffsets, const void *scounts,
       	                  void *dbuf, size_t dcount, size_t el,
+      	                  x10rt_completion_handler *errch,
       	                  x10rt_completion_handler *ch, void *arg)
 {
 	abort(); //not used by Team.x10
@@ -848,17 +849,20 @@ void x10rt_emu_gather (x10rt_team team, x10rt_place role,
 	abort(); //not used by Team.x10
 }
 
-void x10rt_emu_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
+bool x10rt_emu_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
 		                const void *sbuf, size_t scount, void *dbuf,
 		                const void *doffsets, const void *dcounts, size_t el,
+		                x10rt_completion_handler *errch,
 		                x10rt_completion_handler *ch, void *arg)
 {
 	abort(); //not used by Team.x10
 }
 
-void x10rt_emu_bcast (x10rt_team team, x10rt_place role,
+bool x10rt_emu_bcast (x10rt_team team, x10rt_place role,
                       x10rt_place root, const void *sbuf, void *dbuf,
-                      size_t el, size_t count, x10rt_completion_handler *ch, void *arg)
+                      size_t el, size_t count,
+                      x10rt_completion_handler *errch,
+                      x10rt_completion_handler *ch, void *arg)
 {
     TeamObj &t = *gtdb[team];
 
@@ -877,6 +881,7 @@ void x10rt_emu_bcast (x10rt_team team, x10rt_place role,
     m.barrier.root = root;
 
     x10rt_emu_barrier (team, role, ch, arg);
+    return true;
 }
 
 

--- a/x10.runtime/x10rt/common/x10rt_front.cc
+++ b/x10.runtime/x10rt/common/x10rt_front.cc
@@ -204,12 +204,13 @@ void x10rt_barrier (x10rt_team team, x10rt_place role,
     x10rt_lgl_barrier(team, role, ch, arg);
 }
 
-void x10rt_bcast (x10rt_team team, x10rt_place role,
+bool x10rt_bcast (x10rt_team team, x10rt_place role,
                   x10rt_place root, const void *sbuf, void *dbuf,
                   size_t el, size_t count,
+                  x10rt_completion_handler *errch,
                   x10rt_completion_handler *ch, void *arg)
 {
-    x10rt_lgl_bcast(team, role, root, sbuf, dbuf, el, count, ch, arg);
+    return x10rt_lgl_bcast(team, role, root, sbuf, dbuf, el, count, errch, ch, arg);
 }
 
 void x10rt_scatter (x10rt_team team, x10rt_place role,
@@ -220,13 +221,14 @@ void x10rt_scatter (x10rt_team team, x10rt_place role,
     x10rt_lgl_scatter(team, role, root, sbuf, dbuf, el, count, ch, arg);
 }
 
-void x10rt_scatterv (x10rt_team team, x10rt_place role,
+bool x10rt_scatterv (x10rt_team team, x10rt_place role,
                      x10rt_place root, const void *sbuf,
                      const void *soffsets, const void *scounts,
                      void *dbuf, size_t dcount, size_t el,
+                     x10rt_completion_handler *errch,
                      x10rt_completion_handler *ch, void *arg)
 {
-    x10rt_lgl_scatterv(team, role, root, sbuf, soffsets, scounts, dbuf, dcount, el, ch, arg);
+    return x10rt_lgl_scatterv(team, role, root, sbuf, soffsets, scounts, dbuf, dcount, el, errch, ch, arg);
 }
 
 
@@ -238,11 +240,13 @@ void x10rt_gather (x10rt_team team, x10rt_place role,
 	x10rt_lgl_gather (team, role, root, sbuf, dbuf, el, count, ch, arg);
 }
 
-void x10rt_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
+bool x10rt_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
 		            const void *sbuf, size_t scount, void *dbuf, const void *doffsets, const void *dcounts,
-		            size_t el, x10rt_completion_handler *ch, void *arg)
+		            size_t el,
+		            x10rt_completion_handler *errch,
+		            x10rt_completion_handler *ch, void *arg)
 {
-	x10rt_lgl_gatherv (team, role, root, sbuf, scount, dbuf, doffsets, dcounts, el, ch, arg);
+	return x10rt_lgl_gatherv (team, role, root, sbuf, scount, dbuf, doffsets, dcounts, el, errch, ch, arg);
 }
 
 void x10rt_alltoall (x10rt_team team, x10rt_place role,

--- a/x10.runtime/x10rt/common/x10rt_internal.h
+++ b/x10.runtime/x10rt/common/x10rt_internal.h
@@ -148,9 +148,10 @@ X10RT_C void x10rt_emu_team_split (x10rt_team parent, x10rt_place parent_role,
 X10RT_C void x10rt_emu_barrier (x10rt_team team, x10rt_place role,
                                 x10rt_completion_handler *ch, void *arg);
     
-X10RT_C void x10rt_emu_bcast (x10rt_team team, x10rt_place role,
+X10RT_C bool x10rt_emu_bcast (x10rt_team team, x10rt_place role,
                               x10rt_place root, const void *sbuf, void *dbuf,
                               size_t el, size_t count,
+                              x10rt_completion_handler *errch,
                               x10rt_completion_handler *ch, void *arg);
     
 X10RT_C void x10rt_emu_scatter (x10rt_team team, x10rt_place role,
@@ -158,10 +159,11 @@ X10RT_C void x10rt_emu_scatter (x10rt_team team, x10rt_place role,
                                 size_t el, size_t count,
                                 x10rt_completion_handler *ch, void *arg);
 
-X10RT_C void x10rt_emu_scatterv (x10rt_team team, x10rt_place role,
+X10RT_C bool x10rt_emu_scatterv (x10rt_team team, x10rt_place role,
         						 x10rt_place root, const void *sbuf, const void *soffsets, const void *scounts,
         						 void *dbuf, size_t dcount,
         						 size_t el,
+        						 x10rt_completion_handler *errch,
         						 x10rt_completion_handler *ch, void *arg);
 
 X10RT_C void x10rt_emu_gather (x10rt_team team, x10rt_place role,
@@ -169,10 +171,11 @@ X10RT_C void x10rt_emu_gather (x10rt_team team, x10rt_place role,
 							   void *dbuf, size_t el, size_t count,
 							   x10rt_completion_handler *ch, void *arg);
 
-X10RT_C void x10rt_emu_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
+X10RT_C bool x10rt_emu_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
 		                        const void *sbuf, size_t scount, void *dbuf,
 		                        const void *doffsets, const void *dcounts,
 		                        size_t el,
+		                        x10rt_completion_handler *errch,
 		                        x10rt_completion_handler *ch, void *arg);
     
 X10RT_C void x10rt_emu_alltoall (x10rt_team team, x10rt_place role,

--- a/x10.runtime/x10rt/common/x10rt_logical.cc
+++ b/x10.runtime/x10rt/common/x10rt_logical.cc
@@ -1059,17 +1059,19 @@ void x10rt_lgl_barrier (x10rt_team team, x10rt_place role,
     }
 }
 
-void x10rt_lgl_bcast (x10rt_team team, x10rt_place role,
+bool x10rt_lgl_bcast (x10rt_team team, x10rt_place role,
                       x10rt_place root, const void *sbuf, void *dbuf,
                       size_t el, size_t count,
+                      x10rt_completion_handler *errch,
                       x10rt_completion_handler *ch, void *arg)
 {
-    ESCAPE_IF_ERR;
+    ESCAPE_IF_ERR_BOOL;
     if (has_collectives >= X10RT_COLL_ALLBLOCKINGCOLLECTIVES) {
-        x10rt_net_bcast(team, role, root, sbuf, dbuf, el, count, ch, arg);
+        return x10rt_net_bcast(team, role, root, sbuf, dbuf, el, count, errch, ch, arg);
     } else {
-        x10rt_emu_bcast(team, role, root, sbuf, dbuf, el, count, ch, arg);
+        x10rt_emu_bcast(team, role, root, sbuf, dbuf, el, count, errch, ch, arg);
         while (x10rt_emu_coll_probe());
+        return true; //TODO: should not always return true, but x10rt_emu_bcast is not used in Team.x10
     }
 }
 
@@ -1087,18 +1089,20 @@ void x10rt_lgl_scatter (x10rt_team team, x10rt_place role,
     }
 }
 
-void x10rt_lgl_scatterv (x10rt_team team, x10rt_place role,
+bool x10rt_lgl_scatterv (x10rt_team team, x10rt_place role,
                         x10rt_place root, const void *sbuf, const void *soffsets, const void *scounts,
                         void *dbuf, size_t dcount,
                         size_t el,
+                        x10rt_completion_handler *errch,
                         x10rt_completion_handler *ch, void *arg)
 {
-    ESCAPE_IF_ERR;
+    ESCAPE_IF_ERR_BOOL;
     if (has_collectives >= X10RT_COLL_ALLBLOCKINGCOLLECTIVES) {
-        x10rt_net_scatterv(team, role, root, sbuf, soffsets, scounts, dbuf, dcount, el, ch, arg);
+        return x10rt_net_scatterv(team, role, root, sbuf, soffsets, scounts, dbuf, dcount, el, errch, ch, arg);
     } else {
-        x10rt_emu_scatterv(team, role, root, sbuf, soffsets, scounts, dbuf, dcount, el, ch, arg);
+        x10rt_emu_scatterv(team, role, root, sbuf, soffsets, scounts, dbuf, dcount, el, errch, ch, arg);
         while (x10rt_emu_coll_probe());
+        return true; //TODO: should not always return true, but x10rt_emu_scatterv is not used in Team.x10
     }
 }
 
@@ -1116,18 +1120,20 @@ void x10rt_lgl_gather (x10rt_team team, x10rt_place role,
 	}
 }
 
-void x10rt_lgl_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
+bool x10rt_lgl_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
 		               const void *sbuf, size_t scount, void *dbuf,
 		               const void *doffsets, const void *dcounts,
 		               size_t el,
+		               x10rt_completion_handler *errch,
 		               x10rt_completion_handler *ch, void *arg)
 {
-	ESCAPE_IF_ERR;
+	ESCAPE_IF_ERR_BOOL;
 	if (has_collectives >= X10RT_COLL_ALLBLOCKINGCOLLECTIVES) {
-	    x10rt_net_gatherv(team, role, root, sbuf, scount, dbuf, doffsets, dcounts, el, ch, arg);
+	    return x10rt_net_gatherv(team, role, root, sbuf, scount, dbuf, doffsets, dcounts, el, errch, ch, arg);
 	} else {
-	    x10rt_emu_gatherv(team, role, root, sbuf, scount, dbuf, doffsets, dcounts, el, ch, arg);
+	    x10rt_emu_gatherv(team, role, root, sbuf, scount, dbuf, doffsets, dcounts, el, errch, ch, arg);
 	    while (x10rt_emu_coll_probe());
+	    return true;  //TODO: should not always return true, but x10rt_emu_gatherv is not used by Team.x10
 	}
 }
 

--- a/x10.runtime/x10rt/include/x10rt_front.h
+++ b/x10.runtime/x10rt/include/x10rt_front.h
@@ -723,9 +723,10 @@ X10RT_C void x10rt_barrier (x10rt_team team, x10rt_place role,
  *
  * \param arg User pointer that is passed to the completion handler
  */
-X10RT_C void x10rt_bcast (x10rt_team team, x10rt_place role,
+X10RT_C bool x10rt_bcast (x10rt_team team, x10rt_place role,
                           x10rt_place root, const void *sbuf, void *dbuf,
                           size_t el, size_t count,
+                          x10rt_completion_handler *errch,
                           x10rt_completion_handler *ch, void *arg);
 
 /** Asynchronously blocks until all members have received their part of root's array.  Note that
@@ -785,10 +786,11 @@ X10RT_C void x10rt_scatter (x10rt_team team, x10rt_place role,
  *
  * \param arg User pointer that is passed to the completion handler
  */
-X10RT_C void x10rt_scatterv (x10rt_team team, x10rt_place role,
+X10RT_C bool x10rt_scatterv (x10rt_team team, x10rt_place role,
                              x10rt_place root, const void *sbuf,
                              const void *soffsets, const void *scounts,
                              void *dbuf, size_t dcount, size_t el,
+                             x10rt_completion_handler *errch,
                              x10rt_completion_handler *ch, void *arg);
 
 
@@ -846,10 +848,12 @@ X10RT_C void x10rt_gather (x10rt_team team, x10rt_place role,
  *
  * \param arg User pointer that is passed to the completion handler
  */
-X10RT_C void x10rt_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
+X10RT_C bool x10rt_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
 		                        const void *sbuf, size_t scount, void *dbuf,
 		                        const void *doffsets, const void *dcounts,
-		                        size_t el, x10rt_completion_handler *ch, void *arg);
+		                        size_t el,
+		                        x10rt_completion_handler *errch,
+		                        x10rt_completion_handler *ch, void *arg);
 
 /** Asynchronously blocks until all members have received their portion of data from each 
  * member.  Note that sbuf and dbuf are the same size, which is n*el*count where n is the

--- a/x10.runtime/x10rt/include/x10rt_logical.h
+++ b/x10.runtime/x10rt/include/x10rt_logical.h
@@ -390,9 +390,10 @@ X10RT_C void x10rt_lgl_barrier (x10rt_team team, x10rt_place role,
  * \param ch As in #x10rt_bcast
  * \param arg As in #x10rt_bcast
  */
-X10RT_C void x10rt_lgl_bcast (x10rt_team team, x10rt_place role,
+X10RT_C bool x10rt_lgl_bcast (x10rt_team team, x10rt_place role,
                               x10rt_place root, const void *sbuf, void *dbuf,
                               size_t el, size_t count,
+                              x10rt_completion_handler *errch,
                               x10rt_completion_handler *ch, void *arg);
 
 /** \see #x10rt_scatter
@@ -424,11 +425,12 @@ X10RT_C void x10rt_lgl_scatter (x10rt_team team, x10rt_place role,
  * \param ch As in #x10rt_scatterv
  * \param arg As in #x10rt_scatterv
  */
-X10RT_C void x10rt_lgl_scatterv (x10rt_team team, x10rt_place role,
+X10RT_C bool x10rt_lgl_scatterv (x10rt_team team, x10rt_place role,
                                  x10rt_place root, const void *sbuf,
                                  const void *soffsets, const void *scounts,
                                  void *dbuf, size_t dcount,
                                  size_t el,
+                                 x10rt_completion_handler *errch,
                                  x10rt_completion_handler *ch, void *arg);
 
 /** \see #x10rt_gather
@@ -460,10 +462,11 @@ X10RT_C void x10rt_lgl_gather (x10rt_team team, x10rt_place role,
  * \param ch As in #x10rt_gatherv
  * \param arg As in #x10rt_gatherv
  */
-X10RT_C void x10rt_lgl_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
+X10RT_C bool x10rt_lgl_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
 		                const void *sbuf, size_t scount, void *dbuf,
 		                const void *doffsets, const void *dcounts,
 		                size_t el,
+		                x10rt_completion_handler *errch,
 		                x10rt_completion_handler *ch, void *arg);
 
 /** \see #x10rt_alltoall

--- a/x10.runtime/x10rt/include/x10rt_net.h
+++ b/x10.runtime/x10rt/include/x10rt_net.h
@@ -236,9 +236,10 @@ X10RT_C void x10rt_net_barrier (x10rt_team team, x10rt_place role,
  * \param ch As in #x10rt_lgl_bcast
  * \param arg As in #x10rt_lgl_bcast
  */
-X10RT_C void x10rt_net_bcast (x10rt_team team, x10rt_place role,
+X10RT_C bool x10rt_net_bcast (x10rt_team team, x10rt_place role,
                               x10rt_place root, const void *sbuf, void *dbuf,
                               size_t el, size_t count,
+                              x10rt_completion_handler *errch,
                               x10rt_completion_handler *ch, void *arg);
 
 /** \see #x10rt_lgl_scatter
@@ -270,10 +271,11 @@ X10RT_C void x10rt_net_scatter (x10rt_team team, x10rt_place role,
  * \param ch As in #x10rt_lgl_scatterv
  * \param arg As in #x10rt_lgl_scatterv
  */
-X10RT_C void x10rt_net_scatterv (x10rt_team team, x10rt_place role,
+X10RT_C bool x10rt_net_scatterv (x10rt_team team, x10rt_place role,
                                  x10rt_place root, const void *sbuf, const void *soffsets, const void *scounts,
                                  void *dbuf, size_t dcount,
                                  size_t el,
+                                 x10rt_completion_handler *errch,
                                  x10rt_completion_handler *ch, void *arg);
 /** \see #x10rt_lgl_gather
  * \param team As in #x10rt_lgl_gather
@@ -305,9 +307,10 @@ X10RT_C void x10rt_net_gather (x10rt_team team, x10rt_place role,
  * \param ch As in #x10rt_lgl_gatherv
  * \param arg As in #x10rt_lgl_gatherv
  */
-X10RT_C void x10rt_net_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
+X10RT_C bool x10rt_net_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
 		                        const void *sbuf, size_t scount, void *dbuf, const void *doffsets, const void *dcounts,
 		                        size_t el,
+		                        x10rt_completion_handler *errch,
 		                        x10rt_completion_handler *ch, void *arg);
 
 /** \see #x10rt_lgl_alltoall

--- a/x10.runtime/x10rt/jni/jni_team.cc
+++ b/x10.runtime/x10rt/jni/jni_team.cc
@@ -429,7 +429,7 @@ JNIEXPORT void JNICALL Java_x10_x10rt_TeamSupport_nativeScatterImpl(JNIEnv *env,
  * Method:    nativeBcastImpl
  * Signature: (IIILjava/lang/Object;ILjava/lang/Object;IIILx10/lang/FinishState;)V
  */
-JNIEXPORT void JNICALL Java_x10_x10rt_TeamSupport_nativeBcastImpl(JNIEnv *env, jclass klazz,
+JNIEXPORT jobject JNICALL Java_x10_x10rt_TeamSupport_nativeBcastImpl(JNIEnv *env, jclass klazz,
                                                                       jint id, jint role, jint root,
                                                                       jobject src, jint src_off,
                                                                       jobject dst, jint dst_off,
@@ -578,7 +578,7 @@ JNIEXPORT void JNICALL Java_x10_x10rt_TeamSupport_nativeBcastImpl(JNIEnv *env, j
     callbackArg->srcData = srcData;
     callbackArg->dstData = dstData;
 
-    x10rt_bcast(id, role, root, srcData, dstData, el, count, &postCopyCallback, callbackArg);
+    return (jobject)x10rt_bcast(id, role, root, srcData, dstData, el, count, &postCopyCallback, &postCopyCallback, callbackArg);
 }
 
 
@@ -955,7 +955,7 @@ JNIEXPORT jobject JNICALL Java_x10_x10rt_TeamSupport_nativeAllReduceImpl(JNIEnv 
     callbackArg->dstData = dstData;
 
     //FIXME: how to call the correct failure call back?
-    return (jobject) x10rt_allreduce(id, role, srcData, dstData, (x10rt_red_op_type)op, (x10rt_red_type)typecode,
+    return (jobject)x10rt_allreduce(id, role, srcData, dstData, (x10rt_red_op_type)op, (x10rt_red_type)typecode,
                     count, &postCopyCallback, &postCopyCallback, callbackArg);
 }
 

--- a/x10.runtime/x10rt/sockets/x10rt_sockets.cc
+++ b/x10.runtime/x10rt/sockets/x10rt_sockets.cc
@@ -1511,10 +1511,13 @@ void x10rt_net_barrier (x10rt_team team, x10rt_place role, x10rt_completion_hand
 	fatal_error("x10rt_net_barrier not implemented");
 }
 
-void x10rt_net_bcast (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf,
-		void *dbuf, size_t el, size_t count, x10rt_completion_handler *ch, void *arg)
+bool x10rt_net_bcast (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf,
+		void *dbuf, size_t el, size_t count,
+		x10rt_completion_handler *errch,
+		x10rt_completion_handler *ch, void *arg)
 {
 	fatal_error("x10rt_net_bcast not implemented");
+	return false;
 }
 
 void x10rt_net_scatter (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf,
@@ -1523,10 +1526,11 @@ void x10rt_net_scatter (x10rt_team team, x10rt_place role, x10rt_place root, con
 	fatal_error("x10rt_net_scatter not implemented");
 }
 
-void x10rt_net_scatterv (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf, const void *soffsets, const void *scounts,
-		void *dbuf, size_t dcount, size_t el, x10rt_completion_handler *ch, void *arg)
+bool x10rt_net_scatterv (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf, const void *soffsets, const void *scounts,
+		void *dbuf, size_t dcount, size_t el,x10rt_completion_handler *errch, x10rt_completion_handler *ch, void *arg)
 {
 	fatal_error("x10rt_net_scatterv not implemented");
+	return false;
 }
 
 void x10rt_net_gather (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf,
@@ -1535,10 +1539,13 @@ void x10rt_net_gather (x10rt_team team, x10rt_place role, x10rt_place root, cons
 	fatal_error("x10rt_net_gather not implemented");
 }
 
-void x10rt_net_gatherv (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf, size_t scount,
-		void *dbuf, const void *doffsets, const void *dcounts, size_t el, x10rt_completion_handler *ch, void *arg)
+bool x10rt_net_gatherv (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf, size_t scount,
+		void *dbuf, const void *doffsets, const void *dcounts, size_t el,
+        x10rt_completion_handler *errch,
+		x10rt_completion_handler *ch, void *arg)
 {
 	fatal_error("x10rt_net_gatherv not implemented");
+    return false;
 }
 
 void x10rt_net_alltoall (x10rt_team team, x10rt_place role, const void *sbuf, void *dbuf,

--- a/x10.runtime/x10rt/standalone/x10rt_standalone.cc
+++ b/x10.runtime/x10rt/standalone/x10rt_standalone.cc
@@ -971,9 +971,10 @@ void x10rt_net_barrier (x10rt_team team, x10rt_place role,
     abort();
 }
 
-void x10rt_net_bcast (x10rt_team team, x10rt_place role,
+bool x10rt_net_bcast (x10rt_team team, x10rt_place role,
                       x10rt_place root, const void *sbuf, void *dbuf,
                       size_t el, size_t count,
+                      x10rt_completion_handler *errch,
                       x10rt_completion_handler *ch, void *arg)
 {
     abort();
@@ -987,10 +988,11 @@ void x10rt_net_scatter (x10rt_team team, x10rt_place role,
     abort();
 }
 
-void x10rt_net_scatterv (x10rt_team team, x10rt_place role,
+bool x10rt_net_scatterv (x10rt_team team, x10rt_place role,
                          x10rt_place root, const void *sbuf,
                          const void *soffsets, const void *scounts,
                          void *dbuf, size_t dcount, size_t el,
+                         x10rt_completion_handler *errch,
                          x10rt_completion_handler *ch, void *arg)
 {
     abort();
@@ -1004,10 +1006,12 @@ void x10rt_net_gather (x10rt_team team, x10rt_place role,
 	abort();
 }
 
-void x10rt_net_gatherv (x10rt_team team, x10rt_place role,
+bool x10rt_net_gatherv (x10rt_team team, x10rt_place role,
 		                x10rt_place root, const void *sbuf, size_t scount,
 		                void *dbuf, const void *doffsets, const void *dcounts,
-		                size_t el, x10rt_completion_handler *ch, void *arg)
+		                size_t el,
+                        x10rt_completion_handler *errch,
+		                x10rt_completion_handler *ch, void *arg)
 {
 	abort();
 }

--- a/x10.runtime/x10rt/test/x10rt_coll.cc
+++ b/x10.runtime/x10rt/test/x10rt_coll.cc
@@ -145,7 +145,7 @@ static void coll_test (x10rt_team team, x10rt_place role, x10rt_place per_place)
                       << " correctness (if no warnings follow then OK)..." << std::endl;
         finished = 0;
         x10rt_bcast(team, role, root, root==role ? sbuf : NULL, dbuf,
-                    el, count, x10rt_one_setter, &finished);
+                    el, count, x10rt_one_setter, x10rt_one_setter, &finished);
         while (!finished) { x10rt_aborting_probe(); }
         for (size_t i=0 ; i<count ; ++i) {
             float oracle = float(root) * i * i + 1;
@@ -161,7 +161,7 @@ static void coll_test (x10rt_team team, x10rt_place role, x10rt_place per_place)
         taken = -nano_time();
         for (int i=0 ; i<long_tests ; ++i) {
             finished = 0;
-            x10rt_bcast(team, role, root, sbuf, dbuf, el, count, x10rt_one_setter, &finished);
+            x10rt_bcast(team, role, root, sbuf, dbuf, el, count, x10rt_one_setter, x10rt_one_setter, &finished);
             while (!finished) { sched_yield(); x10rt_aborting_probe(); }
         }
         taken += nano_time();


### PR DESCRIPTION
Pull request #5 included only propagating the failure of ULFM allreduce to Team. This pull request does the same changes for Bcast, scatterv and gatherv which are used by the GML apps.