### PR TITLE
delete old snapshot/restore test cases

### DIFF
--- a/x10.gml/tests/distblock/TestDistBlock.x10
+++ b/x10.gml/tests/distblock/TestDistBlock.x10
@@ -72,7 +72,6 @@ public class TestDistBlock extends x10Test {
         ret &= (testScaleAdd(places, team));
         ret &= (testCellMult(places, team));
         ret &= (testCellDiv(places, team));
-	    //ret &= (testSnapshotRestore(places)); TODO: test code needs revision
         return ret;
     }
     
@@ -226,41 +225,6 @@ public class TestDistBlock extends x10Test {
             Console.OUT.println("--------Dist block matrix cellwise mult-div test failed!--------");
         return ret;
     }
-    /*
-    Test case code is not valid after the changes in DistBlockMatrix remake method
-    TODO: rewrite this test method
-    public def testSnapshotRestore(places:PlaceGroup):Boolean {
-        Console.OUT.println("DistBlockMatrix snapshot/restore test");
-        var ret:Boolean = true;
-	
-        val a = DistBlockMatrix.makeDense(grid, dmap, Place.places()).init(1.0);
-        val a_snapshot = a.makeSnapshot();
-        a.init(ET(2.0));
-	
-        val grid1 = grid;
-        val dmap1 = DistGrid.make(grid, places.size()).dmap;
-	
-        a.remakeDense(grid1, dmap1, places);
-        a.restoreSnapshot(a_snapshot);
-	
-        ret &= a.equals(ET(1.0));        
-	
-        var c:DistBlockMatrix = DistBlockMatrix.makeSparse(grid, dmap, nzp, Place.places()).init((r:Long,c:Long)=>ET(1.0));
-        val c1 = c.clone();
-        val c_snapshot = c.makeSnapshot();
-        c.init((r:Long,c:Long)=>ET(5.0));        
-	
-        c.remakeSparse(grid1, dmap1, nzp, places);        
-        c.restoreSnapshot(c_snapshot);
-        for (var i:Long=0; i< c.M; i++)
-            for (var j:Long=0; j< c.N; j++)            
-                ret &= c(i,j) == c1(i,j);
-	
-        if (!ret)
-            Console.OUT.println("--------Dist block matrix snapshot/restore test failed!--------");
-        return ret;
-    }
-    */
     
     public static def main(args:Rail[String]) {
         new TestDistBlock(args).execute();

--- a/x10.gml/tests/distblock/TestDistVector.x10
+++ b/x10.gml/tests/distblock/TestDistVector.x10
@@ -46,7 +46,6 @@ public class TestDistVector extends x10Test {
         ret &= (testCellMult(places));
         ret &= (testCellDiv(places));
         ret &= (testScatterGather(places));
-        ret &= (testSnapshotRestore(places));
         return ret;
     }
     
@@ -176,27 +175,7 @@ public class TestDistVector extends x10Test {
             Console.OUT.println("--------DistVector scatter-gather test failed!--------");
         return ret;
     }
-    
-    public def testSnapshotRestore(places:PlaceGroup):Boolean {
-        Console.OUT.println("Starting distributed vector snapshot/restore test");
-        var dm:DistVector = DistVector.make(M, Place.places(), Team.WORLD).init(ET(1.0));
-	
-        var ret:Boolean = dm.equals(ET(1.0));        
-        val dm_snapshot = dm.makeSnapshot();
-        val dm1 = dm.clone();    
-        dm.cellAdd(ET(2.0)); //change the vector after taking a snapshot        
-        val newPlaceGroup:PlaceGroup = places;    
-        dm.remake(newPlaceGroup, new Team(newPlaceGroup), new ArrayList[Place]());        
-        dm.restoreSnapshot(dm_snapshot);    
-        ret &= !dm.equals(dm1);//different place groups
-        ret &= dm.equals(ET(1.0));
-	
-        if (!ret)
-            Console.OUT.println("--------DistVector snapshot/restore test failed!--------");
-	
-        return ret;
-    }
-    
+
     public static def main(args:Rail[String]) {
         val n = (args.size > 0) ? Long.parse(args(0)):4;
         new TestDistVector(n).execute();

--- a/x10.gml/tests/distblock/TestDupVector.x10
+++ b/x10.gml/tests/distblock/TestDupVector.x10
@@ -45,7 +45,6 @@ public class TestDupVector extends x10Test {
 	    ret &= (testCellMult(places));
 	    ret &= (testCellDiv(places));
 	    ret &= (testReduce(places));
-	    ret &= (testSnapshotRestore(places));
         return ret;
     }
     
@@ -177,29 +176,7 @@ public class TestDupVector extends x10Test {
 	
         return ret;
     }
-    
-    public def testSnapshotRestore(places:PlaceGroup):Boolean {
-        Console.OUT.println("DupVector snapshot/restore test");
-        var dm:DupVector = DupVector.make(M, Place.places(), Team.WORLD).init(ET(1.0));
-        var ret:Boolean = dm.equals(ET(1.0));        
-        val dm_snapshot = dm.makeSnapshot();        
-        dm.cellAdd(ET(2.0)); //change the vector after taking a snapshot       
-	
-        val dm1 = dm.clone();      
-	
-        val newPlaceGroup:PlaceGroup = places;                
-        dm.remake(newPlaceGroup, new Team(newPlaceGroup), new ArrayList[Place]());        
-        dm.restoreSnapshot(dm_snapshot);       
-	
-        ret &= !dm.equals(dm1);//different place groups  
-        ret &= dm.equals(ET(1.0));//restore the old value before the snapshot        
-	
-        if (!ret)
-            Console.OUT.println("--------DupVector snapshot/restore test failed!--------");
-	
-        return ret;
-    }
-    
+
     public static def main(args:Rail[String]) {
         val n = (args.size > 0) ? Long.parse(args(0)):4;
         new TestDupVector(n).execute();


### PR DESCRIPTION
Removing GML test cases that used the old global-view snapshot/restore functions.
