### PR TITLE
Data store and DistBlockMatrix changes

### DIFF
--- a/x10.gml/examples/linreg/LinearRegression.x10
+++ b/x10.gml/examples/linreg/LinearRegression.x10
@@ -215,11 +215,7 @@ public class LinearRegression implements SPMDResilientIterativeApp {
         val newRowPs = changes.newActivePlaces.size();
         val newColPs = 1;
         //remake all the distributed data structures
-        if (nzd < MAX_SPARSE_DENSITY) {
-            X.remakeSparse(newRowPs, newColPs, nzd, changes.newActivePlaces, changes.addedPlaces);
-        } else {
-            X.remakeDense(newRowPs, newColPs, changes.newActivePlaces, changes.addedPlaces);
-        }
+        X.remake(newRowPs, newColPs, changes.newActivePlaces, changes.addedPlaces);
         d_p.remake(changes.newActivePlaces, newTeam, changes.addedPlaces);
         d_q.remake(changes.newActivePlaces, newTeam, changes.addedPlaces);
         d_r.remake(changes.newActivePlaces, newTeam, changes.addedPlaces);

--- a/x10.gml/examples/logreg/LogisticRegression.x10
+++ b/x10.gml/examples/logreg/LogisticRegression.x10
@@ -491,11 +491,7 @@ public class LogisticRegression(N:Long /*nrow (X)*/, D:Long /*ncol (X)*/) implem
         val newRowPs = changes.newActivePlaces.size();        
         val newColPs = 1;
         //remake all the distributed data structures
-        if (nzd < MAX_SPARSE_DENSITY) {
-            X.remakeSparse(newRowPs, newColPs, nzd, changes.newActivePlaces, changes.addedPlaces);
-        } else {
-            X.remakeDense(newRowPs, newColPs, changes.newActivePlaces, changes.addedPlaces);
-        }
+        X.remake(newRowPs, newColPs, changes.newActivePlaces, changes.addedPlaces);
         
         val rowBs = X.getAggRowBs();
         B.remake(changes.newActivePlaces, newTeam, changes.addedPlaces);

--- a/x10.gml/examples/pagerank/PageRank.x10
+++ b/x10.gml/examples/pagerank/PageRank.x10
@@ -303,7 +303,7 @@ public class PageRank implements SPMDResilientIterativeApp {
         if (VERBOSE) Console.OUT.println(here + "Remake, newRowPs["+newRowPs+"], newColPs["+newColPs+"] ...");
         val nzd = nnz as Float / (G.M * G.N);
         // TODO remake using nnz instead of nzd
-        G.remakeSparse(newRowPs, newColPs, nzd, changes.newActivePlaces, changes.addedPlaces);
+        G.remake(newRowPs, newColPs, changes.newActivePlaces, changes.addedPlaces);
         //U.remake(G.getAggRowBs(), changes.newActivePlaces, newTeam, changes.addedPlaces);
         P.remake(changes.newActivePlaces, newTeam, changes.addedPlaces);
         GP.remake(G.getAggRowBs(), changes.newActivePlaces, newTeam, changes.addedPlaces);

--- a/x10.gml/src/x10/matrix/distblock/BlockSet.x10
+++ b/x10.gml/src/x10/matrix/distblock/BlockSet.x10
@@ -49,7 +49,6 @@ public class BlockSet  {
     public var rowCastPlaceMap:CastPlaceMap;
     public var colCastPlaceMap:CastPlaceMap;
 
-    public var snapshotDistInfo:SnapshotDistributionInfo;
     public val placeIndex:Long;
     
     public def this(g:Grid, map:DistMap, placeIndex:Long) {
@@ -59,7 +58,6 @@ public class BlockSet  {
         rowCastPlaceMap=null;
         colCastPlaceMap=null;
         this.placeIndex = placeIndex;
-        snapshotDistInfo = new SnapshotDistributionInfo();
     }
 
     public def this(g:Grid, map:DistMap, bl:ArrayList[MatrixBlock], placeIndex:Long) {
@@ -68,27 +66,6 @@ public class BlockSet  {
         rowCastPlaceMap=null;
         colCastPlaceMap=null;
         this.placeIndex = placeIndex;
-        snapshotDistInfo = new SnapshotDistributionInfo();
-    }
-
-
-    public def this(g:Grid, map:DistMap, placeIndex:Long, snapshotInfo:SnapshotDistributionInfo) {
-        grid=g; dmap = map;
-        blocklist = new ArrayList[MatrixBlock]();    
-        blockMap=null;
-        rowCastPlaceMap=null;
-        colCastPlaceMap=null;
-        this.placeIndex = placeIndex;
-        snapshotDistInfo = snapshotInfo;
-    }
-
-    public def this(g:Grid, map:DistMap, bl:ArrayList[MatrixBlock], placeIndex:Long, snapshotInfo:SnapshotDistributionInfo) {
-        grid=g; dmap = map; blocklist = bl;
-        blockMap = null;
-        rowCastPlaceMap=null;
-        colCastPlaceMap=null;
-        this.placeIndex = placeIndex;
-        snapshotDistInfo = snapshotInfo;
     }
     
     /**
@@ -127,30 +104,12 @@ public class BlockSet  {
         return new BlockSet(gd, dp.dmap, places.indexOf(here));
     }
     
-    public static def makeForRestore(m:Long, n:Long, rowBs:Long, colBs:Long, rowPs:Long, colPs:Long, places:PlaceGroup, 
-            snapshotInfo:SnapshotDistributionInfo) {
-        //val gd = new Grid(m, n, rowBs, colBs); not balanced when considering distribution among rowPs and colPs
-        val gd = DistGrid.makeGrid(m, n, rowBs, colBs, rowPs, colPs);
-        assert (rowPs*colPs == places.size()) :
-              "number of distributions groups of blocks must equal to number of places";
-        val dp = new DistGrid(gd, rowPs, colPs);
-        return new BlockSet(gd, dp.dmap, places.indexOf(here), snapshotInfo);
-    }
-
     public static def make(gd:Grid, rowPs:Long, colPs:Long, places:PlaceGroup) {
         //val gd = new Grid(m, n, rowBs, colBs); not balanced when considering distribution among rowPs and colPs    
         assert (rowPs*colPs == places.size()) :
             "number of distributions groups of blocks must equal to number of places";
         val dp = new DistGrid(gd, rowPs, colPs);
         return new BlockSet(gd, dp.dmap, places.indexOf(here));
-    }
-    
-    public static def makeForRestore(gd:Grid, rowPs:Long, colPs:Long, places:PlaceGroup, snapshotInfo:SnapshotDistributionInfo) {
-        //val gd = new Grid(m, n, rowBs, colBs); not balanced when considering distribution among rowPs and colPs    
-        assert (rowPs*colPs == places.size()) :
-            "number of distributions groups of blocks must equal to number of places";
-        val dp = new DistGrid(gd, rowPs, colPs);
-        return new BlockSet(gd, dp.dmap, places.indexOf(here), snapshotInfo);
     }
     
     /**
@@ -213,9 +172,6 @@ public class BlockSet  {
     public static def makeSparse(g:Grid, d:DistMap, nzd:Float, places:PlaceGroup) =
         new BlockSet(g,d,places.indexOf(here)).allocSparseBlocks(nzd);
     
-    public static def makeSparseForRestore(g:Grid, d:DistMap, nzd:Float, places:PlaceGroup, snapshotInfo:SnapshotDistributionInfo) =
-            new BlockSet(g,d,places.indexOf(here), snapshotInfo).allocSparseBlocks(nzd);       
-
     /**
      * Front row blocks are those blocks which has smallest row ID in the block set in
      * each column block.
@@ -975,51 +931,5 @@ public class BlockSet  {
         }
         return this;
     }   
-}
-
-class SnapshotDistributionInfo{
-    //Grid data
-    public var M:Long;
-    public var N:Long;
-    public var rowBs:Rail[Long];
-    public var colBs:Rail[Long];
-
-    //DistMap data        
-    public var numPlace:Long;
-    public var blockmap:Rail[Long];
-
-    public def this(){	}
-    public def this(M:Long, N:Long, rowBs:Rail[Long], colBs:Rail[Long], numPlace:Long, blockmap:Rail[Long]){
-    	this.M = M;
-    	this.N = N;
-    	this.rowBs = rowBs;
-    	this.colBs = colBs;
-    	this.numPlace = numPlace;
-    	this.blockmap = blockmap;
-    }
-    
-    public def getGrid():Grid {
-        return new Grid(M, N, rowBs, colBs);
-    } 
-
-    public def updateGrid(g:Grid){
-        this.M = g.M;
-        this .N = g.N;
-        this.rowBs = g.rowBs;
-        this.colBs = g.colBs;
-    }
-
-    public def getDistMap():DistMap {
-        return new DistMap(blockmap, numPlace);
-    }
-
-    public def updateDistMap(m:DistMap){
-        this.numPlace = m.numPlace;
-        this.blockmap = m.blockmap;
-    }    
-
-    public def clone() : SnapshotDistributionInfo {
-    	return new SnapshotDistributionInfo(M, N, rowBs, colBs, numPlace, blockmap);
-    }
 }
 

--- a/x10.runtime/src-x10/x10/util/resilient/iterative/GlobalResilientIterativeExecutor.x10
+++ b/x10.runtime/src-x10/x10/util/resilient/iterative/GlobalResilientIterativeExecutor.x10
@@ -194,14 +194,16 @@ public class GlobalResilientIterativeExecutor (home:Place) {
         finish for (p in manager().activePlaces()) at (p) async {
             val ckptMap = appStore.getCheckpointData_local(first);
             if (ckptMap != null) {
+            	val verMap = new HashMap[String,Cloneable]();
                 val iter = ckptMap.keySet().iterator();
                 while (iter.hasNext()) {                    
                     val appKey = iter.next();
                     val key = appKey +":v" + newVersion;
                     val value = ckptMap.getOrThrow(appKey);
-                    resilientMap.set(key, value);
+                    verMap.put(key, value);
                     if (VERBOSE) Console.OUT.println(here + "checkpointing key["+appKey+"]  version["+newVersion+"] succeeded ...");
                 }
+                resilientMap.setAll(verMap);
             }
         }
         appStore.commitCheckpoint(newVersion);

--- a/x10.runtime/src-x10/x10/util/resilient/localstore/LocalStore.x10
+++ b/x10.runtime/src-x10/x10/util/resilient/localstore/LocalStore.x10
@@ -39,16 +39,9 @@ public class LocalStore {
     public def this() { }
 
     /*used when a spare place joins*/
-    public def joinAsMaster (virtualPlaceId:Long, data:HashMap[String,Cloneable], epoch:Long) {
+    public def joinAsMaster (virtualPlaceId:Long, data:HashMap[String,HashMap[String,Cloneable]]) {
         this.virtualPlaceId = virtualPlaceId;
-        masterStore = new MasterStore(virtualPlaceId, data, epoch);
+        masterStore = new MasterStore(virtualPlaceId, data);
         slaveStore = new SlaveStore();
-    }      
-    
-    /*used when a spare place joins*/
-    public def joinAsSlave (masterVirtualPlaceId:Long, masterData:HashMap[String,Cloneable], masterEpoch:Long) {
-        assert(slaveStore != null);
-        slaveStore.addMasterPlace(masterVirtualPlaceId, masterData, new HashMap[String,TransKeyLog](), masterEpoch);
     }
-    
 }

--- a/x10.runtime/src-x10/x10/util/resilient/localstore/LocalTransaction.x10
+++ b/x10.runtime/src-x10/x10/util/resilient/localstore/LocalTransaction.x10
@@ -18,26 +18,25 @@ import x10.util.HashSet;
 import x10.compiler.Ifdef;
 import x10.xrx.Runtime;
 
-public class LocalTransaction (plh:PlaceLocalHandle[LocalStore], id:Long, placeIndex:Long) {
+public class LocalTransaction (plh:PlaceLocalHandle[LocalStore], id:Long, mapName:String, masterMapData:MapData) {
 private val moduleName = "LocalTransaction";
 
     private val transLog:HashMap[String,TransKeyLog] = new HashMap[String,TransKeyLog]();    
-    private var preparedToCommit:Boolean = false;
     private var alive:Boolean = true; // the transaction is alive if it can process more puts and gets
 
     public def put(key:String, newValue:Cloneable):Cloneable {
-    assert(alive);
-    val copiedValue = newValue.clone();    
+        assert(alive);
+        val copiedValue = newValue.clone();    
         var oldValue:Cloneable = null;    
-        val keyLog = transLog.getOrElse(key+placeIndex,null);
+        val keyLog = transLog.getOrElse(key,null);
         if (keyLog != null) { // key used in the transaction before
             oldValue = keyLog.getValue();
             keyLog.update(copiedValue);
         }
         else {// first time to access this key
-            val value = plh().masterStore.getNoCopy(key+placeIndex); // no need to copy, we will overwrite this value any way
+            val value = masterMapData.getNoCopy(key); // no need to copy, we will overwrite this value any way
             val log = new TransKeyLog(value);
-            transLog.put(key+placeIndex, log);
+            transLog.put(key, log);
             log.update(copiedValue);
             oldValue = value;
         }
@@ -46,17 +45,17 @@ private val moduleName = "LocalTransaction";
     
     
     public def delete(key:String):Cloneable {
-    assert(alive);
+    	assert(alive);
         var oldValue:Cloneable = null;    
-        val keyLog = transLog.getOrElse(key+placeIndex,null);
+        val keyLog = transLog.getOrElse(key,null);
         if (keyLog != null) { // key used in the transaction before
             oldValue = keyLog.getValue();
             keyLog.delete();
         }
         else {// first time to access this key
-            val value = plh().masterStore.getNoCopy(key+placeIndex);// no need to copy, we will delete this value any way
+            val value = masterMapData.getNoCopy(key);// no need to copy, we will delete this value any way
             val log = new TransKeyLog(value);
-            transLog.put(key+placeIndex, log);
+            transLog.put(key, log);
             log.delete();
             oldValue = value;
         }
@@ -65,112 +64,48 @@ private val moduleName = "LocalTransaction";
     
     
     public def get(key:String):Cloneable {
-    assert(alive);
+    	assert(alive);
         var oldValue:Cloneable = null;
-        val keyLog = transLog.getOrElse(key+placeIndex,null);
+        val keyLog = transLog.getOrElse(key,null);
         if (keyLog != null) { // key used before in the transaction
            oldValue = keyLog.getValue();
         }
         else {
-            val value = plh().masterStore.getCopy(key+placeIndex);
+            val value = masterMapData.getCopy(key);
             val log = new TransKeyLog(value);
-            transLog.put(key+placeIndex, log);
+            transLog.put(key, log);
             oldValue = value;
         }
         return oldValue;
     }
 
     /**
-     * Dead slave is fatal
-     **/
-    public def prepareAndCommit() {
-        assert(alive);
-        if (isReadOnlyTransaction()){
-            preparedToCommit = true;
-            alive = false;
-            return;
-        }
-        
-        val masterVirtualId = plh().virtualPlaceId;
-        plh().masterStore.epoch++;
-        val masterEpoch = plh().masterStore.epoch;
-        val masterPL = here;
-        at (plh().slave) {
-            plh().slaveStore.addPendingTransaction(masterVirtualId, id, transLog, masterEpoch);
-            plh().slaveStore.commit(masterVirtualId, id, masterEpoch);
-        }
-        //master commit
-        plh().masterStore.commit(id, transLog);
-        
-        preparedToCommit = true;
-        alive = false;
-    }
-    
-    /**
-     * Dead slave is fatal
-     **/
-    public def prepare() {
-    assert(alive);
-    if (isReadOnlyTransaction()){
-        preparedToCommit = true;
-        return;
-        }
-    
-    val masterVirtualId = plh().virtualPlaceId;
-    val masterEpoch = plh().masterStore.epoch;
-    at (plh().slave) {
-            plh().slaveStore.addPendingTransaction(masterVirtualId, id, transLog, masterEpoch);
-        }
-    preparedToCommit = true;
-    }
-    
-    /**
-     * Dead slave is ignored
+     * Dead slave is fatal - 
+     * client should take proper actions to ensure consistency (i.e. repeat the set operation after recovery)
      **/
     public def commit() {
-    assert (alive);
-    
-    if (isReadOnlyTransaction()){
-    return;
-    }
-    
-    assert(preparedToCommit); // non-read-only transactions must be prepared first because they involve interactions with the slave
-    
-        try {
-            plh().masterStore.epoch++;
-            val masterEpoch = plh().masterStore.epoch;
-            val masterVirtualId = plh().virtualPlaceId;
-            at (plh().slave) {
-                plh().slaveStore.commit(masterVirtualId, id, masterEpoch);
-            }
-        }
-        catch(ex:Exception) {
-            //Ignore slave death, because other places who have their slaves active will commit
-        }
+    	try {
+    		assert(alive);
+    		if (isReadOnlyTransaction()){
+    			alive = false;
+    			return;
+    		}
         
-        //master commit
-        plh().masterStore.commit(id, transLog);
-        alive = false;
+    		val masterVirtualId = plh().virtualPlaceId;
+    		val tmpMapName = mapName;
+    		val tmpTransLog = transLog;
+    		val tmpPLH = plh;
+    		at (tmpPLH().slave) {
+    			tmpPLH().slaveStore.commit(tmpMapName, masterVirtualId, tmpTransLog);
+    		}
+    		//master commit
+    		masterMapData.commit(id, transLog);
+    		
+    		alive = false;
+    	} finally {    		
+    		masterMapData.lock.unlock();
+    	}
     }
-    
-    /**
-     * Dead slave is ignored
-     **/
-    public def rollback() {
-    assert (alive);
-        try {
-            val masterVirtualId = plh().virtualPlaceId;
-            at (plh().slave) {
-                plh().slaveStore.rollback(masterVirtualId, id);
-            }
-        }
-        catch(ex:Exception) {            
-        //Ignore slave death, because other places who have their slaves active will rollback 
-        }
-        plh().masterStore.rollback(id);
-        alive = false;
-    }
-    
     
     private def isReadOnlyTransaction():Boolean {
         var result:Boolean = true;

--- a/x10.runtime/src-x10/x10/util/resilient/localstore/MapData.x10
+++ b/x10.runtime/src-x10/x10/util/resilient/localstore/MapData.x10
@@ -1,0 +1,53 @@
+package x10.util.resilient.localstore;
+
+import x10.util.concurrent.SimpleLatch;
+import x10.util.HashMap;
+
+public class MapData {
+	val data:HashMap[String,Cloneable];
+	val lock:SimpleLatch;
+
+    public def this() {
+    	data = new HashMap[String,Cloneable]();
+    	lock = new SimpleLatch();
+    }
+    
+    public def this(data:HashMap[String,Cloneable]) {
+    	this.data = data;
+    	lock = new SimpleLatch();
+    }
+    
+    public def getCopy(key:String):Cloneable {
+        return get(key, true);
+    }
+    
+    public def getNoCopy(key:String):Cloneable {
+    	return get(key, false);
+    }
+    
+    private def get(key:String, copy:Boolean):Cloneable {
+        val value = data.getOrElse(key, null);
+        if (value != null) {
+        	return copy? value.clone(): value;            
+        }
+        else
+        	return null;
+    }
+    
+    public def commit(transId:Long, transLog:HashMap[String,TransKeyLog]) {
+        val iter = transLog.keySet().iterator();
+        while (iter.hasNext()) {
+            val key = iter.next();
+            val log = transLog.getOrThrow(key);
+            if (log.readOnly())
+                continue;
+            if (log.isDeleted()) 
+                data.remove(key);
+            else
+                data.put(key, log.getValue());
+        }        
+    }
+    
+    public def keySet() = data.keySet();
+    
+}

--- a/x10.runtime/src-x10/x10/util/resilient/localstore/MasterStore.x10
+++ b/x10.runtime/src-x10/x10/util/resilient/localstore/MasterStore.x10
@@ -23,106 +23,63 @@ import x10.xrx.Runtime;
 /*Assumption: no local conflicts*/
 public class MasterStore {
     private val moduleName = "MasterStore";
-    public var epoch:Long = 1;
-    private val lock = new Lock();
-    private val data:HashMap[String,Cloneable];
+    private val lock = new Lock();    
+    private val maps:HashMap[String,MapData];
+    
     private val virtualPlaceId:Long;
     val sequence:AtomicLong = new AtomicLong();
-    
-    public val committedTrans = new HashSet[Long]();
-    public val rolledbackTrans = new HashSet[Long]();
     
     //used for original active places joined before any failured
     public def this(virtualPlaceId:Long) {
         this.virtualPlaceId = virtualPlaceId;
-        this.data = new HashMap[String,Cloneable]();
+        this.maps = new HashMap[String,MapData]();
     }
     
     //used when a spare place is replacing a dead one
-    public def this(virtualPlaceId:Long, data:HashMap[String,Cloneable], epoch:Long) {
-        this.virtualPlaceId = virtualPlaceId;
-        this.data = data;
-        this.epoch = epoch;
-    }
-    
-    public def getCopy(key:String):Cloneable {
-        return get(key, true);
-    }
-    
-    public def getNoCopy(key:String):Cloneable {
-    return get(key, false);
-    }
-    
-    private def get(key:String, copy:Boolean):Cloneable {
-        try {
-            lock.lock();
-            val value = data.getOrElse(key, null);
-            if (value != null) {
-            return copy? value.clone(): value;            
-            }
-            else
-            return null;
+    public def this(virtualPlaceId:Long, masterMaps:HashMap[String,HashMap[String,Cloneable]]) {
+        this.virtualPlaceId = virtualPlaceId;   
+        this.maps = new HashMap[String,MapData]();
+        
+        if (masterMaps != null) {
+        	val iter = masterMaps.keySet().iterator();
+        	while (iter.hasNext()) {
+        		val mapName = iter.next();
+        		val mapData = masterMaps.getOrThrow(mapName);
+        		this.maps.put(mapName, new MapData(mapData));
+        	}
         }
-        finally {
-            lock.unlock();
-        }
-    }
-    
-    public def rollback(transId:Long) {
-     try {
-             lock.lock();
-             rolledbackTrans.add(transId);
-         }
-         finally {
-             lock.unlock();
-         }
-    }
-    
-    public def commit(transId:Long, transLog:HashMap[String,TransKeyLog]) {
-        try {
-            lock.lock();
-            val iter = transLog.keySet().iterator();
-            while (iter.hasNext()) {
-                val key = iter.next();
-                val log = transLog.getOrThrow(key);
-                if (log.readOnly())
-                    continue;
-                if (log.isDeleted()) 
-                    data.remove(key);
-                else
-                    data.put(key, log.getValue());
-            }
-            committedTrans.add(transId);
-        }
-        finally {
-            lock.unlock();
-        }
-    }
-    
-    public def getTransactionStatus(transId:Long):Long {
-        try {
-            lock.lock();
-            if (committedTrans.contains(transId))
-                return Constants.TRANS_STATUS_COMMITTED;
-            else if (rolledbackTrans.contains(transId))
-                return Constants.TRANS_STATUS_ROLLEDBACK;
-            else
-                return Constants.TRANS_STATUS_UNFOUND;
-        }
-        finally {
-            lock.unlock();
-        }
-    }
-    
+    }    
+   
     public def getState():MasterState {
         try {
             lock.lock();
-            return new MasterState(data, epoch);
+            val tmp = new HashMap[String,HashMap[String,Cloneable]]();            
+            val iter = maps.keySet().iterator();
+            while (iter.hasNext()) {
+            	val mapName = iter.next();
+            	val mapData = maps.getOrThrow(mapName);
+            	tmp.put(mapName, mapData.data);
+            }            
+            return new MasterState(tmp);
         }
         finally {
             lock.unlock();
         }
     }
-
-    public def keySet() = data.keySet();
+    
+    public def getMapData(mapName:String):MapData {
+    	var data:MapData = null;
+    	try {
+             lock.lock();
+             data = maps.getOrElse(mapName, null);
+             if (data == null) {
+            	 data = new MapData();
+            	 maps.put(mapName, data);
+             }
+        }
+        finally {
+            lock.unlock();
+        }
+    	return data;
+    }
 }

--- a/x10.runtime/src-x10/x10/util/resilient/localstore/ResilientNativeMap.x10
+++ b/x10.runtime/src-x10/x10/util/resilient/localstore/ResilientNativeMap.x10
@@ -1,0 +1,61 @@
+package x10.util.resilient.localstore;
+
+import x10.util.HashSet;
+import x10.util.HashMap;
+
+public class ResilientNativeMap (name:String, plh:PlaceLocalHandle[LocalStore]) {
+    /**
+     * Get the value of key k in the resilient map.
+     */
+    public def get(k:String) {
+        val trans = startLocalTransaction();
+        val v = trans.get(k);
+        trans.commit();
+        return v;
+    }
+
+    /**
+     * Associate value v with key k in the resilient map.
+     */
+    public def set(k:String, v:Cloneable) {
+        val trans = startLocalTransaction();
+        trans.put(k, v);
+        trans.commit();
+    }
+
+    /**
+     * Remove any value associated with key k from the resilient map.
+     */
+    public def delete(k:String) {
+        val trans = startLocalTransaction();
+        trans.delete(k);
+        trans.commit();
+    }
+
+    public def keySet() = plh().masterStore.getMapData(name).keySet();
+    
+    public def setAll(data:HashMap[String,Cloneable]) {
+    	if (data == null)
+    		return;    	
+        val trans = startLocalTransaction();
+        val iter = data.keySet().iterator();
+        while (iter.hasNext()) {
+            val k = iter.next();	
+            trans.put(k, data.getOrThrow(k));
+        }
+        trans.commit();
+    }
+    
+    public def startLocalTransaction():LocalTransaction {
+        assert(plh().virtualPlaceId != -1);
+        val mapData = plh().masterStore.getMapData(name);
+        mapData.lock.lock(); // serialize transactions on the same map
+        return new LocalTransaction(plh, getNextTransactionId(), name, mapData);
+    }
+    
+    public def getNextTransactionId() {
+        val id = plh().masterStore.sequence.incrementAndGet();
+        return 100000+id;
+    }
+    
+}

--- a/x10.runtime/src-x10/x10/util/resilient/localstore/Snapshottable.x10
+++ b/x10.runtime/src-x10/x10/util/resilient/localstore/Snapshottable.x10
@@ -9,7 +9,6 @@
  *  (C) Copyright IBM Corporation 2006-2016.
  *  (C) Copyright Sara Salem Hamouda 2014-2016.
  */
-
 package x10.util.resilient.localstore;
 
 /**

--- a/x10.runtime/src-x10/x10/util/resilient/store/HazelcastStore.x10
+++ b/x10.runtime/src-x10/x10/util/resilient/store/HazelcastStore.x10
@@ -14,6 +14,7 @@ package x10.util.resilient.store;
 import x10.util.resilient.ResilientMap;
 import x10.util.resilient.localstore.Cloneable;
 import x10.util.resilient.PlaceManager.ChangeDescription;
+import x10.util.HashMap;
 
 public class HazelcastStore[V]{V haszero, V <: Cloneable} extends Store[V] {
   static final class LogEntry[V] {
@@ -48,6 +49,15 @@ public class HazelcastStore[V]{V haszero, V <: Cloneable} extends Store[V] {
     setRemote(here, key, value);
   }
 
+  public def setAll(pairs:HashMap[String,V]) {
+	  val iter = pairs.keySet().iterator();
+	  while (iter.hasNext()) {
+		  val k = iter.next();
+		  val v = pairs.getOrThrow(k);
+		  set (k,v);
+	  }
+  }
+  
   public def getRemote(place:Place, key:String) = map.get(k(place, key));
 
   public def setRemote(place:Place, key:String, value:V) {

--- a/x10.runtime/src-x10/x10/util/resilient/store/Store.x10
+++ b/x10.runtime/src-x10/x10/util/resilient/store/Store.x10
@@ -14,6 +14,7 @@ package x10.util.resilient.store;
 import x10.compiler.Native;
 import x10.util.resilient.PlaceManager.ChangeDescription;
 import x10.util.resilient.localstore.Cloneable;
+import x10.util.HashMap;
 
 // a collection of resilient stores, one per place in a place group
 public abstract class Store[V]{V haszero, V <: Cloneable} {
@@ -22,6 +23,9 @@ public abstract class Store[V]{V haszero, V <: Cloneable} {
 
     // set the value for the given key in the local store
     public abstract def set(key:String, value:V):void;
+
+    // set multiple k/v pairs in the local store
+    public abstract def setAll(pairs:HashMap[String,V]):void;
 
     // get the value for the given key at the specified place
     public def getRemote(place:Place, key:String) = at (place) get(key);


### PR DESCRIPTION
1) Added ResilientStore.makeMap(mapName:String) to allow multiple maps to use the same native store.

2) Clean-up native store code: remove prepare(), epoch, and pendingTransactions

3) Added Store.setAll(pairs:HashMap[String,V])  to store multiple K/V pairs. 
In the Hazelcast store, this function is equivalent to calling set(k,v) multiple times. However, in the native store this function is faster than calling set(k,v) multiple times. Each call to set(k,v), in the native store, invokes a communication from the master to the slave. setAll(...) invokes a single communication from master to slave to update multiple keys.

4) Executors use Store.setAll() in checkpointing

5) DistBlockMatrix and Blockset: 
    more clean-up to remove shrinking recovery code, 
    same remake() steps for both sparse and dense matrices
    simplified restoreSnapshot_local()