### PR TITLE
Native support for System.registerPlaceRemovedHandler 

### DIFF
--- a/x10.runtime/src-cpp/x10aux/network.cc
+++ b/x10.runtime/src-cpp/x10aux/network.cc
@@ -26,6 +26,7 @@
 #include <x10/lang/RuntimeNatives.h>
 
 #include <x10/lang/VoidFun_0_0.h>
+#include <x10/lang/VoidFun_0_1.h>
 #include <x10/lang/String.h> // for debug output
 
 #include <x10/lang/Closure.h> // for x10_runtime_Runtime__closure__6
@@ -502,6 +503,21 @@ x10::lang::String *x10aux::runtime_name (void)
     }
     x10::lang::String *str = x10::lang::String::Lit(alloc_printf("%lu@%s", (unsigned long) pid, hname));
     return str;
+}
+
+// Reference to the user callback method
+x10::lang::VoidFun_0_1<x10::lang::Place>* place_removed_handler = NULL;
+
+// Called by the network layer to trigger a callback upon detecting a place failure. //
+void x10aux::notify_place_death(unsigned int pl) {
+	if (place_removed_handler != NULL)
+	    VoidFun_0_1<x10::lang::Place>::__apply(place_removed_handler, x10::lang::Place::_make(x10rt_place(pl)));
+}
+
+// Called by System.registerPlaceRemovedHandler to register a callback method //
+void x10aux::register_place_removed_handler(x10::lang::VoidFun_0_1<x10::lang::Place>* body_fun) {
+    place_removed_handler = body_fun;
+    x10rt_set_place_removed_cb(x10aux::notify_place_death);
 }
 
 // vim:tabstop=4:shiftwidth=4:expandtab

--- a/x10.runtime/src-cpp/x10aux/network.h
+++ b/x10.runtime/src-cpp/x10aux/network.h
@@ -17,7 +17,7 @@
 #include <x10rt_front.h>
 #include <x10rt_cpp.h>
 
-namespace x10 { namespace lang { class VoidFun_0_0; } }
+namespace x10 { namespace lang { struct Place; class VoidFun_0_0; template<class P1> class VoidFun_0_1; } }
 namespace x10 { namespace xrx { class FinishState; } }
 namespace x10 { namespace lang { class Reference; } }
 namespace x10 { namespace lang { class String; } }
@@ -204,6 +204,9 @@ namespace x10aux {
     void coll_handler2(x10rt_team t, void *arg);
     
     void failed_coll_handler(void *arg);
+
+    void register_place_removed_handler(x10::lang::VoidFun_0_1<x10::lang::Place>* body_fun);
+    void notify_place_death(unsigned int place);
 }
 #endif
 // vim:tabstop=4:shiftwidth=4:expandtab

--- a/x10.runtime/src-x10/x10/lang/System.x10
+++ b/x10.runtime/src-x10/x10/lang/System.x10
@@ -139,10 +139,8 @@ public class System {
      * required to execute quickly.
      */
     @Native("java", "x10.x10rt.X10RT.registerPlaceRemovedHandler(#handler)")
-    public static def registerPlaceRemovedHandler(handler:(Place)=>void): void {
-        throw new UnsupportedOperationException("registerPlaceRemovedHandler not implemented for NativeX10");
-    }
-
+    @Native("c++", "::x10aux::register_place_removed_handler(#handler)")
+    public static native def registerPlaceRemovedHandler(handler:(Place)=>void): void ;
 
     /**
      * Sets the exit code with which the X10 program will exit.

--- a/x10.runtime/x10rt/common/x10rt_front.cc
+++ b/x10.runtime/x10rt/common/x10rt_front.cc
@@ -83,6 +83,9 @@ bool x10rt_is_place_dead (x10rt_place p)
 x10rt_error x10rt_get_dead (x10rt_place *dead_places, x10rt_place len)
 { return x10rt_lgl_get_dead(dead_places, len); }
 
+void x10rt_set_place_removed_cb(x10rt_place_removed_callback* cb)
+{ return x10rt_lgl_set_place_removed_cb(cb); }
+
 x10rt_place x10rt_here (void)
 { return x10rt_lgl_here(); }
 

--- a/x10.runtime/x10rt/common/x10rt_logical.cc
+++ b/x10.runtime/x10rt/common/x10rt_logical.cc
@@ -128,6 +128,11 @@ x10rt_error x10rt_lgl_get_dead (x10rt_place *dead_places, x10rt_place len)
 	return x10rt_net_get_dead(dead_places, len);
 }
 
+void x10rt_lgl_set_place_removed_cb(x10rt_place_removed_callback* cb)
+{
+    return x10rt_net_set_place_removed_cb(cb);
+}
+
 x10rt_place x10rt_lgl_here (void)
 {
     return x10rt_net_here();

--- a/x10.runtime/x10rt/include/x10rt_front.h
+++ b/x10.runtime/x10rt/include/x10rt_front.h
@@ -355,6 +355,11 @@ X10RT_C bool x10rt_is_place_dead (x10rt_place p);
  */
 X10RT_C x10rt_error x10rt_get_dead (x10rt_place *dead_places, x10rt_place len);
 
+/** Register a callback method to be called when a place dies.
+ * \param *cb 	the callback method.
+ */
+X10RT_C void x10rt_set_place_removed_cb(x10rt_place_removed_callback* cb);
+
 /** The local place.  An X10 process will discover its
  * own identity by calling this function.
  * \returns The place id of the current place.

--- a/x10.runtime/x10rt/include/x10rt_logical.h
+++ b/x10.runtime/x10rt/include/x10rt_logical.h
@@ -192,6 +192,9 @@ bool x10rt_lgl_is_place_dead (x10rt_place p);
 /** \see #x10rt_get_dead */
 x10rt_error x10rt_lgl_get_dead (x10rt_place *dead_places, x10rt_place len);
 
+/** \see #x10rt_set_place_removed_cb */
+void x10rt_lgl_set_place_removed_cb(x10rt_place_removed_callback* cb);
+
 /** \see #x10rt_here */
 x10rt_place x10rt_lgl_here (void);
 

--- a/x10.runtime/x10rt/include/x10rt_net.h
+++ b/x10.runtime/x10rt/include/x10rt_net.h
@@ -98,6 +98,9 @@ X10RT_C bool x10rt_net_is_place_dead (x10rt_place p);
 /** \see #x10rt_get_dead */
 X10RT_C x10rt_error x10rt_net_get_dead (x10rt_place *dead_places, x10rt_place len);
 
+/** \see #x10rt_set_place_removed_cb */
+X10RT_C void x10rt_net_set_place_removed_cb(x10rt_place_removed_callback* cb);
+
 /** \see #x10rt_lgl_here */
 X10RT_C x10rt_place x10rt_net_here (void);
 

--- a/x10.runtime/x10rt/include/x10rt_types.h
+++ b/x10.runtime/x10rt/include/x10rt_types.h
@@ -49,6 +49,10 @@ typedef void x10rt_completion_handler (void *arg);
  */
 typedef void x10rt_completion_handler2 (x10rt_team, void *arg);
 
+/** User callback to signal that a place has died.
+ */
+typedef void x10rt_place_removed_callback(unsigned int pl);
+
 /** An integer type capable of representing any message type id.
  */
 #if defined(X10RT_32BIT_MSG_IDS) 

--- a/x10.runtime/x10rt/pami/x10rt_pami.cc
+++ b/x10.runtime/x10rt/pami/x10rt_pami.cc
@@ -20,6 +20,7 @@
 #include <pthread.h> // for lock on the team mapping table, and context opening thread
 #include <x10rt_net.h>
 #include <x10rt_internal.h>
+#include <x10rt_types.h>
 #include <pami.h>
 #if !defined(__bgq__)
 #include <pami_ext_hfi.h>

--- a/x10.runtime/x10rt/pami/x10rt_pami.cc
+++ b/x10.runtime/x10rt/pami/x10rt_pami.cc
@@ -2263,3 +2263,10 @@ bool x10rt_net_agree (x10rt_team team, x10rt_place role,
 	error("x10rt_net_agree not implemented");
 	return false;
 }
+
+/* Registering a place removed callback, never used in this implementation */
+x10rt_place_removed_handler* placeRemovedHandler = NULL;
+
+void x10rt_net_set_place_removed_handler(x10rt_place_removed_handler* cb) {
+	placeRemovedHandler = cb;
+}

--- a/x10.runtime/x10rt/standalone/x10rt_standalone.cc
+++ b/x10.runtime/x10rt/standalone/x10rt_standalone.cc
@@ -1059,3 +1059,10 @@ bool x10rt_net_agree (x10rt_team team, x10rt_place role,
 }
 
 const char *x10rt_net_error_msg (void) { return NULL; }
+
+/* Registering a place removed callback, never used in this implementation */
+x10rt_place_removed_callback* placeRemovedCB = NULL;
+
+void x10rt_net_set_place_removed_cb(x10rt_place_removed_callback* cb) {
+	placeRemovedCB = cb;
+}


### PR DESCRIPTION
System.registerPlaceRemovedHandler(..) allows an application to register a callback method to be
called the first time a place is detected to be dead. It was supported only in Managed X10. This PR adds native support to this method. It is one of the changes done to run ResilientUTS.x10 in native mode.

I compiled and tested this change over the sockets and MPI transports only. I didn't compile it over PAMI because I don't have access to a PAMI environment.