### PR TITLE
Avoiding team false invalidation by emulated collectives

### DIFF
--- a/x10.runtime/src-x10/x10/util/Team.x10
+++ b/x10.runtime/src-x10/x10/util/Team.x10
@@ -1162,14 +1162,25 @@ public struct Team {
                     while (!condition() && Team.state(teamidcopy).isValid()) {
                         // look for dead neighboring places
                         if (Team.state(teamidcopy).local_parentIndex > -1 && Team.state(teamidcopy).places(Team.state(teamidcopy).local_parentIndex).isDead()) {
-                            Team.state(teamidcopy).markInvalid();
-                            if (DEBUGINTERNALS) Runtime.println(here+":team"+teamidcopy+" detected place "+Team.state(teamidcopy).places(Team.state(teamidcopy).local_parentIndex)+" is dead!");
+                            //local_parentIndex may be set to -1 in the middle of the above conjunction when a parent place is in between two successive team operations.
+                            //isDead() will return true because Place(-1) does not exist.
+                            //We need to re-execute the above conjunction to avoid falsely marking the team as invalid. 
+                            if (Team.state(teamidcopy).local_parentIndex > -1 && Team.state(teamidcopy).places(Team.state(teamidcopy).local_parentIndex).isDead()) {
+                                Team.state(teamidcopy).markInvalid();
+                                if (DEBUGINTERNALS) Runtime.println(here+":team"+teamidcopy+" detected place "+Team.state(teamidcopy).places(Team.state(teamidcopy).local_parentIndex)+" is dead!");
+                            }
                         } else if (Team.state(teamidcopy).local_child1Index > -1 && Team.state(teamidcopy).places(Team.state(teamidcopy).local_child1Index).isDead()) {
-                            Team.state(teamidcopy).markInvalid();
-                            if (DEBUGINTERNALS) Runtime.println(here+":team"+teamidcopy+" detected place "+Team.state(teamidcopy).places(Team.state(teamidcopy).local_child1Index)+" is dead!");
+                            //re-execute the conjunction for the same reason above
+                            if (Team.state(teamidcopy).local_child1Index > -1 && Team.state(teamidcopy).places(Team.state(teamidcopy).local_child1Index).isDead()) {
+                                Team.state(teamidcopy).markInvalid();
+                                if (DEBUGINTERNALS) Runtime.println(here+":team"+teamidcopy+" detected place "+Team.state(teamidcopy).places(Team.state(teamidcopy).local_child1Index)+" is dead!");
+                            }
                         } else if (Team.state(teamidcopy).local_child2Index > -1 && Team.state(teamidcopy).places(Team.state(teamidcopy).local_child2Index).isDead()) {
-                            Team.state(teamidcopy).markInvalid();
-                            if (DEBUGINTERNALS) Runtime.println(here+":team"+teamidcopy+" detected place "+Team.state(teamidcopy).places(Team.state(teamidcopy).local_child2Index)+" is dead!");
+                            //re-execute the conjunction for the same reason above
+                            if (Team.state(teamidcopy).local_child2Index > -1 && Team.state(teamidcopy).places(Team.state(teamidcopy).local_child2Index).isDead()) {
+                                Team.state(teamidcopy).markInvalid();
+                                if (DEBUGINTERNALS) Runtime.println(here+":team"+teamidcopy+" detected place "+Team.state(teamidcopy).places(Team.state(teamidcopy).local_child2Index)+" is dead!");
+                            }
                         } else {
                             System.threadSleep(0); // release the CPU to more productive pursuits
                         }


### PR DESCRIPTION
Team was vulnerable to false invalidation by sleepUntil(..).
While a parent is resetting its variables at the end of a team operation, a waiting child that started the next team operation may read the reset variables and consider them invalid.
The problem was fixed in by re-checking the conditions that lead to invalidating a team in sleepUntil(..).