### PR TITLE
ULFM-2 support and native collectives cleanup

### DIFF
--- a/x10.runtime/src-cpp/x10aux/network.cc
+++ b/x10.runtime/src-cpp/x10aux/network.cc
@@ -460,13 +460,10 @@ void *x10aux::coll_enter() {
     return fs;
 }
 
-void x10aux::coll_handler(void *arg) {
+void x10aux::coll_handler(void *arg, bool throwDPE) {
     x10::xrx::FinishState* fs = (x10::xrx::FinishState*)arg;
-    fs->notifyActivityTermination();
-}
-//used with ULFM, called only when a collective has failed due to a process failure
-void x10aux::failed_coll_handler(void *arg) {
-    x10::xrx::FinishState* fs = (x10::xrx::FinishState*)arg;
+    if (throwDPE) //triggered only by ULFM when native MPI collectives fail
+    	fs->pushException(x10::lang::DeadPlaceException::_make(x10::lang::String::Lit("[Native] Team contains at least one dead member")));
     fs->notifyActivityTermination();
 }
 

--- a/x10.runtime/src-cpp/x10aux/network.h
+++ b/x10.runtime/src-cpp/x10aux/network.h
@@ -199,12 +199,10 @@ namespace x10aux {
 
     // teams
     void *coll_enter();
-    void coll_handler(void *arg);
+    void coll_handler(void *arg, bool throwDPE);
     void *coll_enter2(void *arg);
     void coll_handler2(x10rt_team t, void *arg);
     
-    void failed_coll_handler(void *arg);
-
     void register_place_removed_handler(x10::lang::VoidFun_0_1<x10::lang::Place>* body_fun);
     void notify_place_death(unsigned int place);
 }

--- a/x10.runtime/src-java/x10/x10rt/TeamSupport.java
+++ b/x10.runtime/src-java/x10/x10rt/TeamSupport.java
@@ -140,9 +140,8 @@ public class TeamSupport {
         }
     }
         
-    public static boolean nativeBcast(int id, int role, int root, Rail<?> src, int src_off, 
+    public static void nativeBcast(int id, int role, int root, Rail<?> src, int src_off, 
                                    Rail<?> dst, int dst_off, int count) {
-    	boolean success = true;
         if (!X10RT.forceSinglePlace) {
         int typeCode = getTypeCode(src);
         assert getTypeCode(dst) == typeCode : "Incompatible src and dst arrays";
@@ -153,12 +152,11 @@ public class TeamSupport {
         FinishState fs = ActivityManagement.activityCreationBookkeeping();
 
         try {
-        	success =nativeBcastImpl(id, role, root, srcRaw, src_off, dstRaw, dst_off, count, typeCode, fs);
+            nativeBcastImpl(id, role, root, srcRaw, src_off, dstRaw, dst_off, count, typeCode, fs);
         } catch (UnsatisfiedLinkError e) {
             aboutToDie("nativeBcast");
         }
         }
-        return success;
     }
 
     public static void nativeAllToAll(int id, int role, Rail<?> src, int src_off, 
@@ -199,9 +197,8 @@ public class TeamSupport {
         }
     }
     
-    public static boolean nativeAllReduce(int id, int role, Rail<?> src, int src_off, 
+    public static void nativeAllReduce(int id, int role, Rail<?> src, int src_off, 
                                        Rail<?> dst, int dst_off, int count, int op) {
-    	boolean success = true;
         if (!X10RT.forceSinglePlace) {
         int typeCode = getTypeCode(src);
         Object srcRaw = typeCode == RED_TYPE_COMPLEX ? copyComplexToNewDouble(src, src_off, count) : src.getBackingArray();
@@ -212,12 +209,11 @@ public class TeamSupport {
         FinishState fs = ActivityManagement.activityCreationBookkeeping();
 
         try {
-            success = nativeAllReduceImpl(id, role, srcRaw, src_off, dstRaw, dst_off, count, op, typeCode, fs);
+            nativeAllReduceImpl(id, role, srcRaw, src_off, dstRaw, dst_off, count, op, typeCode, fs);
         } catch (UnsatisfiedLinkError e) {
             aboutToDie("nativeAllReduce");
         }
         }
-        return success;
     }
 
     public static void nativeIndexOfMax(int id, int role, Rail<?> src,
@@ -296,7 +292,7 @@ public class TeamSupport {
                                                  Object dstRaw, int dst_off,
                                                  int count, int typecode, FinishState fs);
     
-    private static native Boolean nativeBcastImpl(int id, int role, int root, Object srcRaw, int src_off, 
+    private static native void nativeBcastImpl(int id, int role, int root, Object srcRaw, int src_off, 
                                                Object dstRaw, int dst_off,
                                                int count, int typecode, FinishState fs);
     
@@ -308,7 +304,7 @@ public class TeamSupport {
                                                    Object dstRaw, int dst_off,
                                                    int count, int op, int typecode, FinishState fs);
 
-    private static native Boolean nativeAllReduceImpl(int id, int role, Object srcRaw, int src_off, 
+    private static native void nativeAllReduceImpl(int id, int role, Object srcRaw, int src_off, 
                                                    Object dstRaw, int dst_off,
                                                    int count, int op, int typecode, FinishState fs);
     

--- a/x10.runtime/x10rt/common/x10rt_emu_coll.cc
+++ b/x10.runtime/x10rt/common/x10rt_emu_coll.cc
@@ -406,7 +406,7 @@ void x10rt_emu_team_del (x10rt_team team, x10rt_place role, x10rt_completion_han
 {
     assert(gtdb[team]->placev[role] == x10rt_net_here());
     gtdb.releaseTeam(team);
-    ch(arg);
+    ch(arg, false);
 }
 
 namespace {
@@ -519,7 +519,7 @@ static void reduce_c_to_p_update_recv (const x10rt_msg_params *p)
 	}
 	m.reduce.rbuf = recv;
 	if (m.reduce.started) {
-		m.reduce.ch(m.reduce.arg);
+		m.reduce.ch(m.reduce.arg, false);
 	}
 	//fprintf(stderr, "%d: Decrementing child from %d to %d\n", (int)role, (int) m.barrier.wait, (int) m.barrier.wait-1);
 	m.barrier.childToReceive--;
@@ -672,7 +672,7 @@ bool CollOp::progress (void)
                 }
                 safe_free(this);
                 m.bcast.count = 0;  // bcast completed
-                m.barrier.ch(m.barrier.arg);
+                m.barrier.ch(m.barrier.arg, false);
                 return true;
             }
         }
@@ -684,12 +684,12 @@ void CollOp::handlePendingReduce(MemberObj *m) {
     if (m->reduce.count > 0) {
         SYNCHRONIZED (global_lock);
         if (m->reduce.rbuf != NULL) {
-            m->reduce.ch(m->reduce.arg);
+            m->reduce.ch(m->reduce.arg, false);
         }
         if (m->reduce.rbuf2 != NULL) {
             m->reduce.rbuf = m->reduce.rbuf2;
             m->reduce.rbuf2 = NULL;
-            m->reduce.ch(m->reduce.arg);
+            m->reduce.ch(m->reduce.arg, false);
         }
     }
 }
@@ -733,7 +733,7 @@ static void scatter_copy_recv (const x10rt_msg_params *p)
     m.scatter.data_done = true;
     if (m.scatter.barrier_done && m.scatter.ch != NULL) {
         PREEMPT (global_lock);
-        m.scatter.ch(m.scatter.arg);
+        m.scatter.ch(m.scatter.arg, false);
     }
 }
 
@@ -744,7 +744,7 @@ namespace {
     };
 }
 
-static void scatter_after_barrier (void *arg)
+static void scatter_after_barrier (void *arg, bool dummy)
 {
     MemberObj &m = *(static_cast<MemberObj*>(arg));
     TeamObj &t = *gtdb[m.team];
@@ -764,7 +764,7 @@ static void scatter_after_barrier (void *arg)
                 m2->scatter.data_done = true;
                 if (m2->scatter.barrier_done && m2->scatter.ch != NULL) {
                     PREEMPT (global_lock);
-                    m2->scatter.ch(m2->scatter.arg);
+                    m2->scatter.ch(m2->scatter.arg, false);
                 }
             } else {
                 // serialise all the data
@@ -782,7 +782,7 @@ static void scatter_after_barrier (void *arg)
         // the barrier must have completed or we wouldn't even be here
         // signal completion to root role
         if (m.scatter.ch != NULL) {
-            m.scatter.ch(m.scatter.arg);
+            m.scatter.ch(m.scatter.arg, false);
         }
 
     } else {
@@ -792,7 +792,7 @@ static void scatter_after_barrier (void *arg)
         m.scatter.barrier_done = true;
         if (m.scatter.data_done && m.scatter.ch != NULL) {
             PREEMPT (global_lock);
-            m.scatter.ch(m.scatter.arg);
+            m.scatter.ch(m.scatter.arg, false);
         }
     }
 }
@@ -835,7 +835,6 @@ bool  x10rt_emu_scatterv (x10rt_team team, x10rt_place role,
       	                  x10rt_place root, const void *sbuf,
       	                  const void *soffsets, const void *scounts,
       	                  void *dbuf, size_t dcount, size_t el,
-      	                  x10rt_completion_handler *errch,
       	                  x10rt_completion_handler *ch, void *arg)
 {
 	abort(); //not used by Team.x10
@@ -852,7 +851,6 @@ void x10rt_emu_gather (x10rt_team team, x10rt_place role,
 bool x10rt_emu_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
 		                const void *sbuf, size_t scount, void *dbuf,
 		                const void *doffsets, const void *dcounts, size_t el,
-		                x10rt_completion_handler *errch,
 		                x10rt_completion_handler *ch, void *arg)
 {
 	abort(); //not used by Team.x10
@@ -861,7 +859,6 @@ bool x10rt_emu_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
 bool x10rt_emu_bcast (x10rt_team team, x10rt_place role,
                       x10rt_place root, const void *sbuf, void *dbuf,
                       size_t el, size_t count,
-                      x10rt_completion_handler *errch,
                       x10rt_completion_handler *ch, void *arg)
 {
     TeamObj &t = *gtdb[team];
@@ -885,7 +882,7 @@ bool x10rt_emu_bcast (x10rt_team team, x10rt_place role,
 }
 
 
-static void alltoall_intermediate (void *arg)
+static void alltoall_intermediate (void *arg, bool dummy)
 {
     MemberObj &m = *(static_cast<MemberObj*>(arg));
 
@@ -1076,7 +1073,7 @@ namespace {
     };
 
     template<x10rt_red_op_type op, x10rt_red_type dtype>
-    void reduce3 (void *arg)
+    void reduce3 (void *arg, bool dummy)
     {
         MemberObj &m = *(static_cast<MemberObj*>(arg));
 
@@ -1234,7 +1231,7 @@ static void receive_new_team (x10rt_team new_team, void *arg)
     safe_free(m.split.newTeamPlaces);
 }
 
-static void split (void *arg)
+static void split (void *arg, bool dummy)
 {
     MemberObj &m = *(static_cast<MemberObj*>(arg));
     TeamObj &t = *gtdb[m.team];

--- a/x10.runtime/x10rt/common/x10rt_front.cc
+++ b/x10.runtime/x10rt/common/x10rt_front.cc
@@ -210,13 +210,12 @@ void x10rt_barrier (x10rt_team team, x10rt_place role,
     x10rt_lgl_barrier(team, role, ch, arg);
 }
 
-bool x10rt_bcast (x10rt_team team, x10rt_place role,
+void x10rt_bcast (x10rt_team team, x10rt_place role,
                   x10rt_place root, const void *sbuf, void *dbuf,
                   size_t el, size_t count,
-                  x10rt_completion_handler *errch,
                   x10rt_completion_handler *ch, void *arg)
 {
-    return x10rt_lgl_bcast(team, role, root, sbuf, dbuf, el, count, errch, ch, arg);
+    x10rt_lgl_bcast(team, role, root, sbuf, dbuf, el, count, ch, arg);
 }
 
 void x10rt_scatter (x10rt_team team, x10rt_place role,
@@ -227,14 +226,13 @@ void x10rt_scatter (x10rt_team team, x10rt_place role,
     x10rt_lgl_scatter(team, role, root, sbuf, dbuf, el, count, ch, arg);
 }
 
-bool x10rt_scatterv (x10rt_team team, x10rt_place role,
+void x10rt_scatterv (x10rt_team team, x10rt_place role,
                      x10rt_place root, const void *sbuf,
                      const void *soffsets, const void *scounts,
                      void *dbuf, size_t dcount, size_t el,
-                     x10rt_completion_handler *errch,
                      x10rt_completion_handler *ch, void *arg)
 {
-    return x10rt_lgl_scatterv(team, role, root, sbuf, soffsets, scounts, dbuf, dcount, el, errch, ch, arg);
+    x10rt_lgl_scatterv(team, role, root, sbuf, soffsets, scounts, dbuf, dcount, el, ch, arg);
 }
 
 
@@ -246,13 +244,12 @@ void x10rt_gather (x10rt_team team, x10rt_place role,
 	x10rt_lgl_gather (team, role, root, sbuf, dbuf, el, count, ch, arg);
 }
 
-bool x10rt_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
+void x10rt_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
 		            const void *sbuf, size_t scount, void *dbuf, const void *doffsets, const void *dcounts,
 		            size_t el,
-		            x10rt_completion_handler *errch,
 		            x10rt_completion_handler *ch, void *arg)
 {
-	return x10rt_lgl_gatherv (team, role, root, sbuf, scount, dbuf, doffsets, dcounts, el, errch, ch, arg);
+	x10rt_lgl_gatherv (team, role, root, sbuf, scount, dbuf, doffsets, dcounts, el, ch, arg);
 }
 
 void x10rt_alltoall (x10rt_team team, x10rt_place role,
@@ -273,26 +270,24 @@ void x10rt_reduce (x10rt_team team, x10rt_place role,
     x10rt_lgl_reduce(team, role, root, sbuf, dbuf, op, dtype, count, ch, arg);
 }
 
-bool x10rt_allreduce (x10rt_team team, x10rt_place role,
+void x10rt_allreduce (x10rt_team team, x10rt_place role,
                       const void *sbuf, void *dbuf,
                       x10rt_red_op_type op, 
                       x10rt_red_type dtype,
                       size_t count,
-                      x10rt_completion_handler *errch,
                       x10rt_completion_handler *ch, void *arg)
 {
-    return x10rt_lgl_allreduce(team, role, sbuf, dbuf, op, dtype, count, errch, ch, arg);
+    x10rt_lgl_allreduce(team, role, sbuf, dbuf, op, dtype, count, ch, arg);
 }
 
-bool x10rt_agree (x10rt_team team, x10rt_place role,
+void x10rt_agree (x10rt_team team, x10rt_place role,
                              const int *sbuf, int *dbuf,
-                             x10rt_completion_handler *errch,
                              x10rt_completion_handler *ch, void *arg)
 {
-	return x10rt_lgl_agree(team, role, sbuf, dbuf, errch, ch, arg);
+	x10rt_lgl_agree(team, role, sbuf, dbuf, ch, arg);
 }
 
-void x10rt_one_setter (void *arg)
+void x10rt_one_setter (void *arg, bool dummy)
 { *((int*)arg) = 1; }
 
 void x10rt_team_setter (x10rt_team v, void *arg)

--- a/x10.runtime/x10rt/common/x10rt_internal.h
+++ b/x10.runtime/x10rt/common/x10rt_internal.h
@@ -151,7 +151,6 @@ X10RT_C void x10rt_emu_barrier (x10rt_team team, x10rt_place role,
 X10RT_C bool x10rt_emu_bcast (x10rt_team team, x10rt_place role,
                               x10rt_place root, const void *sbuf, void *dbuf,
                               size_t el, size_t count,
-                              x10rt_completion_handler *errch,
                               x10rt_completion_handler *ch, void *arg);
     
 X10RT_C void x10rt_emu_scatter (x10rt_team team, x10rt_place role,
@@ -163,7 +162,6 @@ X10RT_C bool x10rt_emu_scatterv (x10rt_team team, x10rt_place role,
         						 x10rt_place root, const void *sbuf, const void *soffsets, const void *scounts,
         						 void *dbuf, size_t dcount,
         						 size_t el,
-        						 x10rt_completion_handler *errch,
         						 x10rt_completion_handler *ch, void *arg);
 
 X10RT_C void x10rt_emu_gather (x10rt_team team, x10rt_place role,
@@ -175,7 +173,6 @@ X10RT_C bool x10rt_emu_gatherv (x10rt_team team, x10rt_place role, x10rt_place r
 		                        const void *sbuf, size_t scount, void *dbuf,
 		                        const void *doffsets, const void *dcounts,
 		                        size_t el,
-		                        x10rt_completion_handler *errch,
 		                        x10rt_completion_handler *ch, void *arg);
     
 X10RT_C void x10rt_emu_alltoall (x10rt_team team, x10rt_place role,

--- a/x10.runtime/x10rt/include/x10rt_front.h
+++ b/x10.runtime/x10rt/include/x10rt_front.h
@@ -733,10 +733,9 @@ X10RT_C void x10rt_barrier (x10rt_team team, x10rt_place role,
  *
  * \param arg User pointer that is passed to the completion handler
  */
-X10RT_C bool x10rt_bcast (x10rt_team team, x10rt_place role,
+X10RT_C void x10rt_bcast (x10rt_team team, x10rt_place role,
                           x10rt_place root, const void *sbuf, void *dbuf,
                           size_t el, size_t count,
-                          x10rt_completion_handler *errch,
                           x10rt_completion_handler *ch, void *arg);
 
 /** Asynchronously blocks until all members have received their part of root's array.  Note that
@@ -796,11 +795,10 @@ X10RT_C void x10rt_scatter (x10rt_team team, x10rt_place role,
  *
  * \param arg User pointer that is passed to the completion handler
  */
-X10RT_C bool x10rt_scatterv (x10rt_team team, x10rt_place role,
+X10RT_C void x10rt_scatterv (x10rt_team team, x10rt_place role,
                              x10rt_place root, const void *sbuf,
                              const void *soffsets, const void *scounts,
                              void *dbuf, size_t dcount, size_t el,
-                             x10rt_completion_handler *errch,
                              x10rt_completion_handler *ch, void *arg);
 
 
@@ -858,11 +856,10 @@ X10RT_C void x10rt_gather (x10rt_team team, x10rt_place role,
  *
  * \param arg User pointer that is passed to the completion handler
  */
-X10RT_C bool x10rt_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
+X10RT_C void x10rt_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
 		                        const void *sbuf, size_t scount, void *dbuf,
 		                        const void *doffsets, const void *dcounts,
 		                        size_t el,
-		                        x10rt_completion_handler *errch,
 		                        x10rt_completion_handler *ch, void *arg);
 
 /** Asynchronously blocks until all members have received their portion of data from each 
@@ -948,12 +945,11 @@ X10RT_C void x10rt_reduce (x10rt_team team, x10rt_place role,
  *
  * \param arg User pointer that is passed to the completion handler
  */
-X10RT_C bool x10rt_allreduce (x10rt_team team, x10rt_place role,
+X10RT_C void x10rt_allreduce (x10rt_team team, x10rt_place role,
                               const void *sbuf, void *dbuf,
                               x10rt_red_op_type op,
                               x10rt_red_type dtype,
                               size_t count,
-                              x10rt_completion_handler *errch,
                               x10rt_completion_handler *ch, void *arg);
 
 
@@ -971,15 +967,14 @@ X10RT_C bool x10rt_allreduce (x10rt_team team, x10rt_place role,
  *
  * \param arg User pointer that is passed to the completion handler
  */
-X10RT_C bool x10rt_agree (x10rt_team team, x10rt_place role,
+X10RT_C void x10rt_agree (x10rt_team team, x10rt_place role,
                              const int *sbuf, int *dbuf,
-                             x10rt_completion_handler *errch,
                              x10rt_completion_handler *ch, void *arg);
 
 /** Sets arg to 1.
  * \param arg Assumed to be an int*
  */
-X10RT_C void x10rt_one_setter (void *arg);
+X10RT_C void x10rt_one_setter (void *arg, bool throwDPE);
 
 /** Sets arg to the given team.
  * \param v The new team is passed in here

--- a/x10.runtime/x10rt/include/x10rt_logical.h
+++ b/x10.runtime/x10rt/include/x10rt_logical.h
@@ -398,10 +398,9 @@ X10RT_C void x10rt_lgl_barrier (x10rt_team team, x10rt_place role,
  * \param ch As in #x10rt_bcast
  * \param arg As in #x10rt_bcast
  */
-X10RT_C bool x10rt_lgl_bcast (x10rt_team team, x10rt_place role,
+X10RT_C void x10rt_lgl_bcast (x10rt_team team, x10rt_place role,
                               x10rt_place root, const void *sbuf, void *dbuf,
                               size_t el, size_t count,
-                              x10rt_completion_handler *errch,
                               x10rt_completion_handler *ch, void *arg);
 
 /** \see #x10rt_scatter
@@ -433,12 +432,11 @@ X10RT_C void x10rt_lgl_scatter (x10rt_team team, x10rt_place role,
  * \param ch As in #x10rt_scatterv
  * \param arg As in #x10rt_scatterv
  */
-X10RT_C bool x10rt_lgl_scatterv (x10rt_team team, x10rt_place role,
+X10RT_C void x10rt_lgl_scatterv (x10rt_team team, x10rt_place role,
                                  x10rt_place root, const void *sbuf,
                                  const void *soffsets, const void *scounts,
                                  void *dbuf, size_t dcount,
                                  size_t el,
-                                 x10rt_completion_handler *errch,
                                  x10rt_completion_handler *ch, void *arg);
 
 /** \see #x10rt_gather
@@ -470,11 +468,10 @@ X10RT_C void x10rt_lgl_gather (x10rt_team team, x10rt_place role,
  * \param ch As in #x10rt_gatherv
  * \param arg As in #x10rt_gatherv
  */
-X10RT_C bool x10rt_lgl_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
+X10RT_C void x10rt_lgl_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
 		                const void *sbuf, size_t scount, void *dbuf,
 		                const void *doffsets, const void *dcounts,
 		                size_t el,
-		                x10rt_completion_handler *errch,
 		                x10rt_completion_handler *ch, void *arg);
 
 /** \see #x10rt_alltoall
@@ -521,12 +518,11 @@ X10RT_C void x10rt_lgl_reduce (x10rt_team team, x10rt_place role,
  * \param ch As in #x10rt_allreduce
  * \param arg As in #x10rt_allreduce
  */
-X10RT_C bool x10rt_lgl_allreduce (x10rt_team team, x10rt_place role,
+X10RT_C void x10rt_lgl_allreduce (x10rt_team team, x10rt_place role,
                                   const void *sbuf, void *dbuf,
                                   x10rt_red_op_type op,
                                   x10rt_red_type dtype,
                                   size_t count,
-                                  x10rt_completion_handler *errch,
                                   x10rt_completion_handler *ch, void *arg);
 
 /** \see #x10rt_agree
@@ -537,9 +533,8 @@ X10RT_C bool x10rt_lgl_allreduce (x10rt_team team, x10rt_place role,
  * \param ch As in #x10rt_allreduce
  * \param arg As in #x10rt_allreduce
  */
-X10RT_C bool x10rt_lgl_agree (x10rt_team team, x10rt_place role,
+X10RT_C void x10rt_lgl_agree (x10rt_team team, x10rt_place role,
                              const int *sbuf, int *dbuf,
-                             x10rt_completion_handler *errch,
                              x10rt_completion_handler *ch, void *arg);
 
 #endif

--- a/x10.runtime/x10rt/include/x10rt_net.h
+++ b/x10.runtime/x10rt/include/x10rt_net.h
@@ -245,10 +245,9 @@ X10RT_C void x10rt_net_barrier (x10rt_team team, x10rt_place role,
  * \param ch As in #x10rt_lgl_bcast
  * \param arg As in #x10rt_lgl_bcast
  */
-X10RT_C bool x10rt_net_bcast (x10rt_team team, x10rt_place role,
+X10RT_C void x10rt_net_bcast (x10rt_team team, x10rt_place role,
                               x10rt_place root, const void *sbuf, void *dbuf,
                               size_t el, size_t count,
-                              x10rt_completion_handler *errch,
                               x10rt_completion_handler *ch, void *arg);
 
 /** \see #x10rt_lgl_scatter
@@ -280,11 +279,10 @@ X10RT_C void x10rt_net_scatter (x10rt_team team, x10rt_place role,
  * \param ch As in #x10rt_lgl_scatterv
  * \param arg As in #x10rt_lgl_scatterv
  */
-X10RT_C bool x10rt_net_scatterv (x10rt_team team, x10rt_place role,
+X10RT_C void x10rt_net_scatterv (x10rt_team team, x10rt_place role,
                                  x10rt_place root, const void *sbuf, const void *soffsets, const void *scounts,
                                  void *dbuf, size_t dcount,
                                  size_t el,
-                                 x10rt_completion_handler *errch,
                                  x10rt_completion_handler *ch, void *arg);
 /** \see #x10rt_lgl_gather
  * \param team As in #x10rt_lgl_gather
@@ -316,10 +314,9 @@ X10RT_C void x10rt_net_gather (x10rt_team team, x10rt_place role,
  * \param ch As in #x10rt_lgl_gatherv
  * \param arg As in #x10rt_lgl_gatherv
  */
-X10RT_C bool x10rt_net_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
+X10RT_C void x10rt_net_gatherv (x10rt_team team, x10rt_place role, x10rt_place root,
 		                        const void *sbuf, size_t scount, void *dbuf, const void *doffsets, const void *dcounts,
 		                        size_t el,
-		                        x10rt_completion_handler *errch,
 		                        x10rt_completion_handler *ch, void *arg);
 
 /** \see #x10rt_lgl_alltoall
@@ -366,12 +363,11 @@ X10RT_C void x10rt_net_reduce (x10rt_team team, x10rt_place role,
  * \param ch As in #x10rt_lgl_allreduce
  * \param arg As in #x10rt_lgl_allreduce
  */
-X10RT_C bool x10rt_net_allreduce (x10rt_team team, x10rt_place role,
+X10RT_C void x10rt_net_allreduce (x10rt_team team, x10rt_place role,
                                   const void *sbuf, void *dbuf,
                                   x10rt_red_op_type op,
                                   x10rt_red_type dtype,
                                   size_t count,
-                                  x10rt_completion_handler *errch,
                                   x10rt_completion_handler *ch, void *arg);
 
 
@@ -383,9 +379,8 @@ X10RT_C bool x10rt_net_allreduce (x10rt_team team, x10rt_place role,
  * \param ch As in #x10rt_allreduce
  * \param arg As in #x10rt_allreduce
  */
-X10RT_C bool x10rt_net_agree (x10rt_team team, x10rt_place role,
+X10RT_C void x10rt_net_agree (x10rt_team team, x10rt_place role,
                              const int *sbuf, int *dbuf,
-                             x10rt_completion_handler *errch,
                              x10rt_completion_handler *ch, void *arg);
 
 

--- a/x10.runtime/x10rt/include/x10rt_types.h
+++ b/x10.runtime/x10rt/include/x10rt_types.h
@@ -43,7 +43,7 @@ typedef uint32_t x10rt_team;
 
 /** User callback to signal that non-blocking operations have completed.
  */
-typedef void x10rt_completion_handler (void *arg);
+typedef void x10rt_completion_handler (void *arg, bool throwDPE);
 
 /** User callback to signal that non-blocking team construction operations have completed.
  */

--- a/x10.runtime/x10rt/jni/jni_team.cc
+++ b/x10.runtime/x10rt/jni/jni_team.cc
@@ -111,7 +111,7 @@ typedef struct finishOnlyStruct {
     jobject globalFinishState;
 } finishOnlyStruct;
 
-static void finishOnlyCallback(void *arg) {
+static void finishOnlyCallback(void *arg, bool throwDPE) {
     finishOnlyStruct* callbackArg = (finishOnlyStruct*)arg;
     JNIEnv *env = jniHelper_getEnv();
 
@@ -166,7 +166,7 @@ typedef struct postCopyStruct {
     void *dstData;
 } postCopyStruct;
 
-static void postCopyCallback(void *arg) {
+static void postCopyCallback(void *arg, bool dummy) {
     postCopyStruct *callbackArg = (postCopyStruct*)arg;
     JNIEnv *env = jniHelper_getEnv();
 
@@ -429,7 +429,7 @@ JNIEXPORT void JNICALL Java_x10_x10rt_TeamSupport_nativeScatterImpl(JNIEnv *env,
  * Method:    nativeBcastImpl
  * Signature: (IIILjava/lang/Object;ILjava/lang/Object;IIILx10/lang/FinishState;)V
  */
-JNIEXPORT jobject JNICALL Java_x10_x10rt_TeamSupport_nativeBcastImpl(JNIEnv *env, jclass klazz,
+JNIEXPORT void JNICALL Java_x10_x10rt_TeamSupport_nativeBcastImpl(JNIEnv *env, jclass klazz,
                                                                       jint id, jint role, jint root,
                                                                       jobject src, jint src_off,
                                                                       jobject dst, jint dst_off,
@@ -578,7 +578,7 @@ JNIEXPORT jobject JNICALL Java_x10_x10rt_TeamSupport_nativeBcastImpl(JNIEnv *env
     callbackArg->srcData = srcData;
     callbackArg->dstData = dstData;
 
-    return (jobject)x10rt_bcast(id, role, root, srcData, dstData, el, count, &postCopyCallback, &postCopyCallback, callbackArg);
+    x10rt_bcast(id, role, root, srcData, dstData, el, count, &postCopyCallback, callbackArg);
 }
 
 
@@ -854,7 +854,7 @@ JNIEXPORT void JNICALL Java_x10_x10rt_TeamSupport_nativeReduceImpl(JNIEnv *env, 
  * Method:    nativeAllReduceImpl
  * Signature: (IILjava/lang/Object;ILjava/lang/Object;IIIILx10/lang/FinishState;)V
  */
-JNIEXPORT jobject JNICALL Java_x10_x10rt_TeamSupport_nativeAllReduceImpl(JNIEnv *env, jclass klazz,
+JNIEXPORT void JNICALL Java_x10_x10rt_TeamSupport_nativeAllReduceImpl(JNIEnv *env, jclass klazz,
                                                                       jint id, jint role,
                                                                       jobject src, jint src_off,
                                                                       jobject dst, jint dst_off,
@@ -954,9 +954,8 @@ JNIEXPORT jobject JNICALL Java_x10_x10rt_TeamSupport_nativeAllReduceImpl(JNIEnv 
     callbackArg->srcData = srcData;
     callbackArg->dstData = dstData;
 
-    //FIXME: how to call the correct failure call back?
-    return (jobject)x10rt_allreduce(id, role, srcData, dstData, (x10rt_red_op_type)op, (x10rt_red_type)typecode,
-                    count, &postCopyCallback, &postCopyCallback, callbackArg);
+    x10rt_allreduce(id, role, srcData, dstData, (x10rt_red_op_type)op, (x10rt_red_type)typecode,
+                    count, &postCopyCallback, callbackArg);
 }
 
 
@@ -976,7 +975,7 @@ typedef struct minmaxStruct {
     DoubleIdx *dstData;
 } minmaxStruct;
 
-static void minmaxCallback(void *arg) {
+static void minmaxCallback(void *arg, bool dummy) {
     minmaxStruct *callbackArg = (minmaxStruct*)arg;
     JNIEnv *env = jniHelper_getEnv();
 
@@ -1024,7 +1023,7 @@ static void indexOfImpl(JNIEnv *env, jint id, jint role,
     callbackArg->srcData = srcData;
     callbackArg->dstData = dstData;
 
-    x10rt_allreduce(id, role, srcData, dstData, op, X10RT_RED_TYPE_DBL_S32, 1, &minmaxCallback, &minmaxCallback, callbackArg);
+    x10rt_allreduce(id, role, srcData, dstData, op, X10RT_RED_TYPE_DBL_S32, 1, &minmaxCallback, callbackArg);
 }
 
 

--- a/x10.runtime/x10rt/sockets/x10rt_sockets.cc
+++ b/x10.runtime/x10rt/sockets/x10rt_sockets.cc
@@ -1618,13 +1618,11 @@ void x10rt_net_barrier (x10rt_team team, x10rt_place role, x10rt_completion_hand
 	fatal_error("x10rt_net_barrier not implemented");
 }
 
-bool x10rt_net_bcast (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf,
+void x10rt_net_bcast (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf,
 		void *dbuf, size_t el, size_t count,
-		x10rt_completion_handler *errch,
 		x10rt_completion_handler *ch, void *arg)
 {
 	fatal_error("x10rt_net_bcast not implemented");
-	return false;
 }
 
 void x10rt_net_scatter (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf,
@@ -1633,11 +1631,10 @@ void x10rt_net_scatter (x10rt_team team, x10rt_place role, x10rt_place root, con
 	fatal_error("x10rt_net_scatter not implemented");
 }
 
-bool x10rt_net_scatterv (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf, const void *soffsets, const void *scounts,
-		void *dbuf, size_t dcount, size_t el,x10rt_completion_handler *errch, x10rt_completion_handler *ch, void *arg)
+void x10rt_net_scatterv (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf, const void *soffsets, const void *scounts,
+		void *dbuf, size_t dcount, size_t el, x10rt_completion_handler *ch, void *arg)
 {
 	fatal_error("x10rt_net_scatterv not implemented");
-	return false;
 }
 
 void x10rt_net_gather (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf,
@@ -1646,13 +1643,11 @@ void x10rt_net_gather (x10rt_team team, x10rt_place role, x10rt_place root, cons
 	fatal_error("x10rt_net_gather not implemented");
 }
 
-bool x10rt_net_gatherv (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf, size_t scount,
+void x10rt_net_gatherv (x10rt_team team, x10rt_place role, x10rt_place root, const void *sbuf, size_t scount,
 		void *dbuf, const void *doffsets, const void *dcounts, size_t el,
-        x10rt_completion_handler *errch,
 		x10rt_completion_handler *ch, void *arg)
 {
 	fatal_error("x10rt_net_gatherv not implemented");
-    return false;
 }
 
 void x10rt_net_alltoall (x10rt_team team, x10rt_place role, const void *sbuf, void *dbuf,
@@ -1671,20 +1666,17 @@ void x10rt_net_reduce (x10rt_team team, x10rt_place role,
 	fatal_error("x10rt_net_reduce not implemented");
 }
 
-bool x10rt_net_allreduce (x10rt_team team, x10rt_place role, const void *sbuf, void *dbuf,
-		x10rt_red_op_type op, x10rt_red_type dtype, size_t count,x10rt_completion_handler *errch, x10rt_completion_handler *ch, void *arg)
+void x10rt_net_allreduce (x10rt_team team, x10rt_place role, const void *sbuf, void *dbuf,
+		x10rt_red_op_type op, x10rt_red_type dtype, size_t count, x10rt_completion_handler *ch, void *arg)
 {
 	fatal_error("x10rt_net_allreduce not implemented");
-	return false;
 }
 
-bool x10rt_net_agree (x10rt_team team, x10rt_place role,
+void x10rt_net_agree (x10rt_team team, x10rt_place role,
                              const int *sbuf, int *dbuf,
-                             x10rt_completion_handler *errch,
                              x10rt_completion_handler *ch, void *arg)
 {
 	fatal_error("x10rt_net_agree not implemented");
-	return false;
 }
 
 const char *x10rt_net_error_msg (void) { return context.errorMsg; }

--- a/x10.runtime/x10rt/standalone/x10rt_standalone.cc
+++ b/x10.runtime/x10rt/standalone/x10rt_standalone.cc
@@ -976,10 +976,9 @@ void x10rt_net_barrier (x10rt_team team, x10rt_place role,
     abort();
 }
 
-bool x10rt_net_bcast (x10rt_team team, x10rt_place role,
+void x10rt_net_bcast (x10rt_team team, x10rt_place role,
                       x10rt_place root, const void *sbuf, void *dbuf,
                       size_t el, size_t count,
-                      x10rt_completion_handler *errch,
                       x10rt_completion_handler *ch, void *arg)
 {
     abort();
@@ -993,11 +992,10 @@ void x10rt_net_scatter (x10rt_team team, x10rt_place role,
     abort();
 }
 
-bool x10rt_net_scatterv (x10rt_team team, x10rt_place role,
+void x10rt_net_scatterv (x10rt_team team, x10rt_place role,
                          x10rt_place root, const void *sbuf,
                          const void *soffsets, const void *scounts,
                          void *dbuf, size_t dcount, size_t el,
-                         x10rt_completion_handler *errch,
                          x10rt_completion_handler *ch, void *arg)
 {
     abort();
@@ -1011,11 +1009,10 @@ void x10rt_net_gather (x10rt_team team, x10rt_place role,
 	abort();
 }
 
-bool x10rt_net_gatherv (x10rt_team team, x10rt_place role,
+void x10rt_net_gatherv (x10rt_team team, x10rt_place role,
 		                x10rt_place root, const void *sbuf, size_t scount,
 		                void *dbuf, const void *doffsets, const void *dcounts,
 		                size_t el,
-                        x10rt_completion_handler *errch,
 		                x10rt_completion_handler *ch, void *arg)
 {
 	abort();
@@ -1039,20 +1036,18 @@ void x10rt_net_reduce (x10rt_team team, x10rt_place role,
 	abort();
 }
 
-bool x10rt_net_allreduce (x10rt_team team, x10rt_place role,
+void x10rt_net_allreduce (x10rt_team team, x10rt_place role,
                           const void *sbuf, void *dbuf,
                           x10rt_red_op_type op, 
                           x10rt_red_type dtype,
                           size_t count,
-                          x10rt_completion_handler *errch,
                           x10rt_completion_handler *ch, void *arg)
 {
     abort();
 }
 
-bool x10rt_net_agree (x10rt_team team, x10rt_place role,
+void x10rt_net_agree (x10rt_team team, x10rt_place role,
                              const int *sbuf, int *dbuf,
-                             x10rt_completion_handler *errch,
                              x10rt_completion_handler *ch, void *arg)
 {
     abort();

--- a/x10.runtime/x10rt/test/x10rt_coll.cc
+++ b/x10.runtime/x10rt/test/x10rt_coll.cc
@@ -145,7 +145,7 @@ static void coll_test (x10rt_team team, x10rt_place role, x10rt_place per_place)
                       << " correctness (if no warnings follow then OK)..." << std::endl;
         finished = 0;
         x10rt_bcast(team, role, root, root==role ? sbuf : NULL, dbuf,
-                    el, count, x10rt_one_setter, x10rt_one_setter, &finished);
+                    el, count, x10rt_one_setter, &finished);
         while (!finished) { x10rt_aborting_probe(); }
         for (size_t i=0 ; i<count ; ++i) {
             float oracle = float(root) * i * i + 1;
@@ -161,7 +161,7 @@ static void coll_test (x10rt_team team, x10rt_place role, x10rt_place per_place)
         taken = -nano_time();
         for (int i=0 ; i<long_tests ; ++i) {
             finished = 0;
-            x10rt_bcast(team, role, root, sbuf, dbuf, el, count, x10rt_one_setter, x10rt_one_setter, &finished);
+            x10rt_bcast(team, role, root, sbuf, dbuf, el, count, x10rt_one_setter, &finished);
             while (!finished) { sched_yield(); x10rt_aborting_probe(); }
         }
         taken += nano_time();
@@ -318,7 +318,6 @@ static void coll_test (x10rt_team team, x10rt_place role, x10rt_place per_place)
             std::cout<<team<<": allreduce correctness (if no errors then OK):" << std::endl;
         finished = 0;
         x10rt_allreduce(team, role, sbuf, dbuf, X10RT_RED_OP_ADD, X10RT_RED_TYPE_FLT, count,
-        		            x10rt_one_setter,
                             x10rt_one_setter, &finished);
         while (!finished) { x10rt_aborting_probe(); }
         float oracle_base = (x10rt_team_sz(team)*x10rt_team_sz(team) + x10rt_team_sz(team))/2;
@@ -338,7 +337,7 @@ static void coll_test (x10rt_team team, x10rt_place role, x10rt_place per_place)
         for (int i=0 ; i<long_tests ; ++i) {
             finished = 0;
             x10rt_allreduce(team, role, sbuf, dbuf, X10RT_RED_OP_ADD, X10RT_RED_TYPE_FLT, count,
-                                x10rt_one_setter, x10rt_one_setter, &finished);
+                                x10rt_one_setter, &finished);
             while (!finished) { sched_yield(); x10rt_aborting_probe(); }
         }
         taken += nano_time();

--- a/x10.tests/tests/MicroBenchmarks/BenchmarkAgree.x10
+++ b/x10.tests/tests/MicroBenchmarks/BenchmarkAgree.x10
@@ -1,0 +1,42 @@
+/*
+ *  This file is part of the X10 project (http://x10-lang.org).
+ *
+ *  This file is licensed to You under the Eclipse Public License (EPL);
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *      http://www.opensource.org/licenses/eclipse-1.0.php
+ *
+ *  (C) Copyright IBM Corporation 2014-2016.
+ *  (C) Copyright Sara Salem Hamouda 2018.
+ */
+import harness.x10Test;
+
+import x10.util.Team;
+
+/**
+ * Benchmarks performance of Team.agree
+ */
+public class BenchmarkAgree extends x10Test {
+    private static ITERS = 1000;
+
+	public def run(): Boolean {
+        finish for (place in Place.places()) at (place) async {
+            Team.WORLD.agree(0n); // warm up comms layer
+            val start = System.nanoTime();
+            for (iter in 1..ITERS) {
+                val out = Team.WORLD.agree(iter as Int);
+                // check correctness
+                chk((iter as Int) == out, here + " agreement not reached expected["+iter+"] found["+out+"]");
+            }
+            val stop = System.nanoTime();
+
+            if (here == Place.FIRST_PLACE) Console.OUT.printf("agree: %g ms\n", ((stop-start) as Double) / 1e6 / ITERS);
+        }
+
+        return true;
+	}
+
+	public static def main(var args: Rail[String]): void {
+		new BenchmarkAgree().execute();
+	}
+}

--- a/x10.tests/tests/MicroBenchmarks/BenchmarkScatterV.x10
+++ b/x10.tests/tests/MicroBenchmarks/BenchmarkScatterV.x10
@@ -30,7 +30,7 @@ public class BenchmarkScatterV extends x10Test {
             val warmupIn = new Rail[Double](NPLACES);
             var warmupOut:Rail[Double] = new Rail[Double](1);
             val warmupCounts = new Rail[Int](NPLACES, 1n);
-            Team.WORLD.scatterv(root,warmupIn, 0, warmupOut, 0, warmupCounts); // warm up comms layer
+            Team.WORLD.scatterv(root, warmupIn, 0, warmupOut, 0, warmupCounts); // warm up comms layer
 
             for (var s:Long= 1; s <= MAX_S; s++) {
                 var src:Rail[Double] = null;
@@ -44,7 +44,7 @@ public class BenchmarkScatterV extends x10Test {
                     src = new Rail[Double](srcSize);
                     var lastPlaceId:Long = 0;
                     var it:Long = SRC_OFFSET;
-                    //initialize the src rail so that each place segment contains its the place id as a value
+                    //initialize the src rail so that each place segment contains its place id as a value
                     while(it<srcSize){
                         for (var j:Long = 0; j < (Math.pow(2,s)*(lastPlaceId+1)) as Long; j++){
                             src(it++) = lastPlaceId;


### PR DESCRIPTION
1- supporting a recent release of ULFM that provides non-blocking collectives.
2- rolling back to the old mechanism of notifying the completion of a native collective call using a local finish, rather than a boolean return value from X10RT functions.