### PR TITLE
Fix compile bug on modern C++ compilers

### DIFF
--- a/x10.runtime/x10rt/mpi/x10rt_mpi.cc
+++ b/x10.runtime/x10rt/mpi/x10rt_mpi.cc
@@ -62,7 +62,7 @@
 
 #define X10RT_NET_DEBUGV(fmt, var) do { \
     if(coll_state.is_enabled_debug_print) { \
-        fprintf(stderr, "[%s:%d:%s] (%"PRIu32") " #var " = %"fmt "\n", __FILE__, __LINE__, __func__, static_cast<uint32_t>((global_state.init && !global_state.finalized)? x10rt_net_here() : -1), (var)); \
+        fprintf(stderr, "[%s:%d:%s] (%" PRIu32 ") " #var " = %" fmt "\n", __FILE__, __LINE__, __func__, static_cast<uint32_t>((global_state.init && !global_state.finalized)? x10rt_net_here() : -1), (var)); \
     } \
 }while(false)
 


### PR DESCRIPTION
On Cray systems if I try to build with the Cray wrapper compilers, I get the following compiler error:

```
     [exec] mpi/x10rt_mpi.cc:65:66: error: unable to find string literal operator 'operator""fmt' with 'const char [49]', 'long unsigned int' arguments
     [exec]          fprintf(stderr, "[%s:%d:%s] (%"PRIu32") " #var " = %"fmt "\n", __FILE__, __LINE__, __func__, static_cast<uint32_t>((global_state.init && !global_state.finalized)? x10rt_net_here() : -1), (var)); \
     [exec]                                                                   ^
     [exec] mpi/x10rt_mpi.cc:2597:5: note: in expansion of macro 'X10RT_NET_DEBUGV'
     [exec]      X10RT_NET_DEBUGV("d",coll_state.TEAM_CALLBACK_ID);
     [exec]      ^~~~~~~~~~~~~~~~
```

This appears to be due to the introduction of [user-defined string literals in C++11](https://stackoverflow.com/a/6402166/188046). A string with a variable immediately following (`"asdf"zxcv`) it is no longer string concatenation, but a user-defined string literal. You need a space if you want to force it to do string concatenation (`"asdf" zxcv`).

This patch fixes the bug by adding spaces around the variable names.