### PR TITLE
Fix vim indentation file

### DIFF
--- a/x10.common/contrib/vim/indent/x10.vim
+++ b/x10.common/contrib/vim/indent/x10.vim
@@ -15,7 +15,7 @@ let b:did_indent = 1
 
 setlocal indentexpr=GetX10Indent()
 
-setlocal indentkeys=0{,0},0),!^F,<>>,<CR>
+setlocal indentkeys=0{,0},0),!^F,<>>,o,O
 
 setlocal autoindent sw=2 et
 


### PR DESCRIPTION
Also indent on pressing 'o' and 'O' in normal mode.

Note that `o` includes `<CR>` (reference: http://vimdoc.sourceforge.net/htmldoc/indent.html#indentkeys-format)