### PR TITLE
[APGAS] Fix ignored UnknownHostException in selecting a good ip for the host while booting

### DIFF
--- a/apgas/src/apgas/impl/GlobalRuntimeImpl.java
+++ b/apgas/src/apgas/impl/GlobalRuntimeImpl.java
@@ -276,6 +276,15 @@ public final class GlobalRuntimeImpl extends GlobalRuntime {
       if (host == null) {
         host = localhost;
       }
+      {
+        // removing port part from IPv4 addresses
+        int lastIndex;
+        if ((lastIndex = host.lastIndexOf(':')) > 0
+                && lastIndex == host.indexOf(':')) {
+          host=host.substring(0, lastIndex);
+        }
+      }
+
       try {
         final Enumeration<NetworkInterface> networkInterfaces = NetworkInterface
             .getNetworkInterfaces();


### PR DESCRIPTION
`host` variable has form _IP:port_, so the (ignored) exception occurs:
```
java.net.UnknownHostException: 192.168.0.100:5701: invalid IPv6 address
        at java.net.InetAddress.getAllByName(InetAddress.java:1170)
        at java.net.InetAddress.getAllByName(InetAddress.java:1127)
        at java.net.InetAddress.getByName(InetAddress.java:1077)
        at apgas.impl.GlobalRuntimeImpl.<init>(GlobalRuntimeImpl.java:289)
        at apgas.GlobalRuntime$GlobalRuntimeWrapper.<clinit>(GlobalRuntime.java:41)
        at apgas.GlobalRuntime.getRuntimeImpl(GlobalRuntime.java:65)
        at apgas.GlobalRuntime.getRuntime(GlobalRuntime.java:56)
        at apgas.GlobalRuntime.main(GlobalRuntime.java:98)
```
Removing port part from the host name fixes the issue.